### PR TITLE
Add URLs to thread and comment output by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,9 +42,19 @@ make build              # Build gh-helper tool
 ## Development Workflow
 
 ### Branch Management
+- **Always fetch before creating branches**: Run `git fetch origin` before creating any new branch
+- **Base branches on origin/main**: Always create feature branches from `origin/main` to ensure they include latest changes
 - **Feature branches**: Always create feature branches for development
 - **Pull Requests**: All changes must go through PR review
 - **No direct commits**: Never commit directly to main branch
+
+Example:
+```bash
+# Always fetch latest changes first
+git fetch origin
+# Create branch from latest origin/main
+git checkout -b feature/new-feature origin/main
+```
 
 ### Testing and Quality
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,8 +90,9 @@ git commit -m "fix: address review feedback"
 
 ### Automated Review Management
 - **Gemini Code Assist**: Provides automatic initial review but requires explicit request for follow-up reviews
-- **Request additional reviews**: Comment `/gemini review` on PR for re-review after significant changes
-- **Initial review only**: After first automated review, no additional reviews come automatically
+- **Initial PR creation**: Gemini automatically reviews new PRs, no `--request-review` flag needed initially
+- **Follow-up reviews**: Use `--request-review` flag or comment `/gemini review` for re-review after significant changes
+- **Important**: `--request-review` is only needed for subsequent reviews, not for newly created PRs
 
 ### Pull Request Merging
 - **ALWAYS use Squash and Merge**: Never use regular merge or rebase merge

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ git push origin HEAD  # Explicit push to current branch
 
 ### Review Thread Management
 - **Always resolve review threads** after addressing feedback
-- **CRITICAL: Push commits BEFORE replying to threads** - GitHub needs the commit to exist for proper linking
+- **CRITICAL:** Push commits BEFORE replying to threads - GitHub needs the commit to exist for proper linking
 - **For threads requiring code changes**:
   1. Make the necessary changes and commit
   2. **Push the commit to GitHub first**: `git push origin HEAD`

--- a/gh-helper/github.go
+++ b/gh-helper/github.go
@@ -185,7 +185,7 @@ func (c *GitHubClient) RunGraphQLQueryWithVariables(query string, variables map[
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			slog.Warn("failed to close response body", "url", resp.Request.URL, "error", err)
+			slog.Warn("failed to close response body", "url", resp.Request.URL.String(), "error", err)
 		}
 	}()
 

--- a/gh-helper/main.go
+++ b/gh-helper/main.go
@@ -416,7 +416,7 @@ func performAsyncReviewCheck(client *GitHubClient, prNumber string) error {
 	} else {
 		// Provide more specific error information for non-file-not-found errors
 		if !os.IsNotExist(err) {
-			slog.Warn("failed to load previous review state", "pr", prNumber, "error", err)
+			slog.Info("failed to load previous review state", "pr", prNumber, "error", err)
 		}
 		WarningMsg("No previous state found or state could not be loaded, showing all recent reviews...").Print()
 		fmt.Printf("\n📋 Found %d review(s) total\n", len(data.Reviews))

--- a/gh-helper/main.go
+++ b/gh-helper/main.go
@@ -419,7 +419,7 @@ func performAsyncReviewCheck(client *GitHubClient, prNumber string) error {
 	} else {
 		// Provide more specific error information for non-file-not-found errors
 		if !os.IsNotExist(err) {
-			slog.Info("failed to load previous review state", "pr", prNumber, "error", err)
+			slog.Warn("failed to load previous review state", "pr", prNumber, "error", err)
 		}
 		WarningMsg("No previous state found or state could not be loaded, showing all recent reviews...").Print()
 		fmt.Printf("\n📋 Found %d review(s) total\n", len(data.Reviews))
@@ -860,7 +860,10 @@ func showThread(cmd *cobra.Command, args []string) error {
 	format := ResolveFormat(cmd)
 	
 	// Get exclude-urls flag
-	excludeURLs, _ := cmd.Flags().GetBool("exclude-urls")
+	excludeURLs, err := cmd.Flags().GetBool("exclude-urls")
+	if err != nil {
+		return fmt.Errorf("failed to read 'exclude-urls' flag: %w", err)
+	}
 
 	// Use batch query for multiple threads or single thread
 	threadsMap, err := client.GetThreadBatch(args, excludeURLs)

--- a/gh-helper/main.go
+++ b/gh-helper/main.go
@@ -101,7 +101,7 @@ This command polls every 30 seconds and waits until BOTH conditions are met:
 Use --exclude-reviews to wait for PR checks only.
 Use --exclude-checks to wait for reviews only.
 Use --request-review to automatically request Gemini review before waiting.
-Use --async to check once and return immediately (replaces 'reviews check').
+Use --async to check reviews once and return immediately (non-blocking).
 
 `+prNumberArgsHelp+`
 

--- a/gh-helper/reviews_unified.go
+++ b/gh-helper/reviews_unified.go
@@ -64,6 +64,7 @@ func init() {
 	// Convenience flags
 	fetchReviewsCmd.Flags().Bool("no-threads", false, "Exclude threads (shorthand for --threads=false)")
 	fetchReviewsCmd.Flags().Bool("no-bodies", false, "Exclude bodies (shorthand for --bodies=false)")
+	fetchReviewsCmd.Flags().Bool("exclude-urls", false, "Exclude URLs from output")
 }
 
 func fetchReviews(cmd *cobra.Command, args []string) error {
@@ -89,6 +90,9 @@ func fetchReviews(cmd *cobra.Command, args []string) error {
 	// Get output format using unified resolver
 	format := ResolveFormat(cmd)
 	
+	// Get exclude-urls flag
+	excludeURLs, _ := cmd.Flags().GetBool("exclude-urls")
+	
 	// Adjust flags for thread-focused modes
 	if listThreads || threadsOnly {
 		format = FormatJSON // Force JSON for thread-focused modes
@@ -105,6 +109,7 @@ func fetchReviews(cmd *cobra.Command, args []string) error {
 		ThreadLimit:         threadLimit,
 		ReviewLimit:         reviewLimit,
 		NeedsReplyOnly:      needsReplyOnly,
+		ExcludeURLs:         excludeURLs,
 	}
 
 	// Use structured logging (slog) for consistent format with JSON/YAML output
@@ -150,7 +155,7 @@ func fetchReviews(cmd *cobra.Command, args []string) error {
 		return EncodeOutput(os.Stdout, format, data)
 	}
 	
-	// Use specialized output function for better structure
+	// Use specialized output function for better structure  
 	return outputFetch(data, includeReviewBodies, includeThreads, format)
 }
 
@@ -230,6 +235,11 @@ func outputFetch(data *UnifiedReviewData, includeReviewBodies bool, includeThrea
 					"isOutdated": thread.IsOutdated,
 				}
 				
+				// Include URL only if not empty (respects @skip directive)
+				if thread.URL != "" {
+					threadData["url"] = thread.URL
+				}
+				
 				// Add comment information
 				if len(thread.Comments) > 0 {
 					last := thread.Comments[len(thread.Comments)-1]
@@ -238,12 +248,19 @@ func outputFetch(data *UnifiedReviewData, includeReviewBodies bool, includeThrea
 					// Include all comments with author information
 					comments := []map[string]interface{}{}
 					for _, comment := range thread.Comments {
-						comments = append(comments, map[string]interface{}{
+						commentData := map[string]interface{}{
 							"id":        comment.ID,
 							"author":    comment.Author,
 							"createdAt": comment.CreatedAt,
 							"body":      comment.Body,
-						})
+						}
+						
+						// Include URL only if not empty (respects @skip directive)
+						if comment.URL != "" {
+							commentData["url"] = comment.URL
+						}
+						
+						comments = append(comments, commentData)
 					}
 					threadData["comments"] = comments
 				}

--- a/gh-helper/reviews_unified.go
+++ b/gh-helper/reviews_unified.go
@@ -91,7 +91,10 @@ func fetchReviews(cmd *cobra.Command, args []string) error {
 	format := ResolveFormat(cmd)
 	
 	// Get exclude-urls flag
-	excludeURLs, _ := cmd.Flags().GetBool("exclude-urls")
+	excludeURLs, err := cmd.Flags().GetBool("exclude-urls")
+	if err != nil {
+		return fmt.Errorf("failed to read 'exclude-urls' flag: %w", err)
+	}
 	
 	// Adjust flags for thread-focused modes
 	if listThreads || threadsOnly {


### PR DESCRIPTION
## Summary
Enhance gh-helper with comprehensive URL support for improved GitHub navigation and workflow efficiency.

## Changes Made
- **Default URL inclusion**: Thread and comment URLs now included in all output by default
- **GraphQL optimization**: Uses `@skip(if: $excludeUrls)` directive for conditional URL fetching
- **Flexible control**: Added `--exclude-urls` flag for lightweight output when needed
- **Enhanced data structures**: Updated ThreadInfo, CommentInfo, ThreadData, ThreadComment with URL fields
- **Clean output handling**: Empty URLs automatically excluded via `omitempty` tags

## Technical Implementation
- Updated GraphQL queries in `threads.go`, `unified_review.go` with conditional URL fetching
- Enhanced API methods: `GetThreadBatch`, `GetUnifiedReviewData` with `excludeURLs` parameter
- Added command flags to `reviews fetch` and `threads show` commands
- Implemented clean output processing that respects GraphQL directives

## Usage Examples
```bash
# URLs included by default
gh-helper threads show THREAD_ID
gh-helper reviews fetch 4 --threads-only

# URLs excluded for lightweight output  
gh-helper threads show THREAD_ID --exclude-urls
gh-helper reviews fetch 4 --exclude-urls
```

## Benefits
- **Improved navigation**: Direct links to GitHub threads and comments
- **CI/CD integration**: Easy link generation for notifications
- **Bandwidth optimization**: Conditional URL fetching via GraphQL
- **Backward compatibility**: Default behavior enhanced, optional exclusion available

🤖 Generated with [Claude Code](https://claude.ai/code)