### PR TITLE
feat: implement bulk label operations (Issue #7)

### DIFF
--- a/gh-helper/github.go
+++ b/gh-helper/github.go
@@ -722,7 +722,7 @@ func (c *GitHubClient) GetLabelIDs(labelNames []string) (map[string]string, erro
 		return nil, fmt.Errorf("failed to parse labels response: %w", err)
 	}
 
-	labelMap := make(map[string]string)
+	labelMap := make(map[string]string, len(labelNames))
 	for _, label := range response.Data.Repository.Labels.Nodes {
 		labelMap[label.Name] = label.ID
 	}

--- a/gh-helper/github.go
+++ b/gh-helper/github.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -692,4 +693,294 @@ func (c *GitHubClient) ResolvePRNumber(input string) (int, string, error) {
 	default:
 		return 0, "", fmt.Errorf("unknown input format type: %s", format.Type)
 	}
+}
+
+// GetLabelIDs fetches label IDs by names
+func (c *GitHubClient) GetLabelIDs(labelNames []string) (map[string]string, error) {
+	query := LabelFragment + `
+	query($owner: String!, $repo: String!) {
+		repository(owner: $owner, name: $repo) {
+			labels(first: 100) {
+				nodes {
+					...LabelFields
+				}
+			}
+		}
+	}`
+
+	variables := map[string]interface{}{
+		"owner": c.Owner,
+		"repo":  c.Repo,
+	}
+
+	var response GetLabelIDsResponse
+	responseBytes, err := c.RunGraphQLQueryWithVariables(query, variables)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch labels: %w", err)
+	}
+	if err := Unmarshal(responseBytes, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse labels response: %w", err)
+	}
+
+	labelMap := make(map[string]string)
+	for _, label := range response.Data.Repository.Labels.Nodes {
+		labelMap[label.Name] = label.ID
+	}
+
+	return labelMap, nil
+}
+
+// GetLabelableInfo fetches information about an issue or PR
+func (c *GitHubClient) GetLabelableInfo(repoID string, itemType string, number int) (*LabelableInfo, error) {
+	// If itemType is empty, we need to auto-detect
+	if itemType == "" {
+		node, err := c.ResolveNumber(number)
+		if err != nil {
+			return nil, err
+		}
+		itemType = node.NodeType
+	}
+
+	query := LabelFragment + `
+	query($owner: String!, $repo: String!, $number: Int!) {
+		repository(owner: $owner, name: $repo) {
+			issue(number: $number) @include(if: $isIssue) {
+				id
+				number
+				title
+				__typename
+				labels(first: 100) {
+					nodes {
+						...LabelFields
+					}
+				}
+			}
+			pullRequest(number: $number) @include(if: $isPR) {
+				id
+				number
+				title
+				__typename
+				labels(first: 100) {
+					nodes {
+						...LabelFields
+					}
+				}
+			}
+		}
+	}`
+
+	isIssue := itemType == "Issue"
+	isPR := itemType == "PullRequest"
+
+	variables := map[string]interface{}{
+		"owner":   c.Owner,
+		"repo":    c.Repo,
+		"number":  number,
+		"isIssue": isIssue,
+		"isPR":    isPR,
+	}
+
+	var response GetLabelableInfoResponse
+	responseBytes, err := c.RunGraphQLQueryWithVariables(query, variables)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch item info: %w", err)
+	}
+	if err := Unmarshal(responseBytes, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse item info response: %w", err)
+	}
+
+	if isIssue && response.Data.Repository.Issue != nil {
+		return response.Data.Repository.Issue, nil
+	}
+	if isPR && response.Data.Repository.PullRequest != nil {
+		return response.Data.Repository.PullRequest, nil
+	}
+
+	return nil, fmt.Errorf("item #%d not found", number)
+}
+
+// SearchItemsByTitle searches for issues and PRs by title pattern
+func (c *GitHubClient) SearchItemsByTitle(repoID string, re *regexp.Regexp) ([]ItemToLabel, error) {
+	// GitHub search doesn't support regex, so we'll fetch all and filter
+	query := `
+	query($owner: String!, $repo: String!) {
+		repository(owner: $owner, name: $repo) {
+			issues(first: 100, states: OPEN) {
+				nodes {
+					id
+					number
+					title
+					__typename
+				}
+			}
+			pullRequests(first: 100, states: OPEN) {
+				nodes {
+					id
+					number
+					title
+					__typename
+				}
+			}
+		}
+	}`
+
+	variables := map[string]interface{}{
+		"owner": c.Owner,
+		"repo":  c.Repo,
+	}
+
+	var response struct {
+		Data struct {
+			Repository struct {
+				Issues struct {
+					Nodes []LabelableInfo `json:"nodes"`
+				} `json:"issues"`
+				PullRequests struct {
+					Nodes []LabelableInfo `json:"nodes"`
+				} `json:"pullRequests"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+
+	responseBytes, err := c.RunGraphQLQueryWithVariables(query, variables)
+	if err != nil {
+		return nil, fmt.Errorf("failed to search items: %w", err)
+	}
+	if err := Unmarshal(responseBytes, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse search response: %w", err)
+	}
+
+	var items []ItemToLabel
+	
+	// Filter issues by regex
+	for _, issue := range response.Data.Repository.Issues.Nodes {
+		if re.MatchString(issue.Title) {
+			items = append(items, ItemToLabel{
+				ID:     issue.ID,
+				Number: issue.Number,
+				Type:   issue.TypeName,
+				Title:  issue.Title,
+			})
+		}
+	}
+
+	// Filter PRs by regex
+	for _, pr := range response.Data.Repository.PullRequests.Nodes {
+		if re.MatchString(pr.Title) {
+			items = append(items, ItemToLabel{
+				ID:     pr.ID,
+				Number: pr.Number,
+				Type:   pr.TypeName,
+				Title:  pr.Title,
+			})
+		}
+	}
+
+	return items, nil
+}
+
+// AddLabelsToItem adds labels to a single item
+func (c *GitHubClient) AddLabelsToItem(itemID string, labelIDs []string) (*LabelableInfo, error) {
+	mutation := AllLabelFragments + `
+	mutation($input: AddLabelsToLabelableInput!) {
+		addLabelsToLabelable(input: $input) {
+			labelable {
+				...LabelableFields
+			}
+		}
+	}`
+
+	variables := map[string]interface{}{
+		"input": map[string]interface{}{
+			"labelableId": itemID,
+			"labelIds":    labelIDs,
+		},
+	}
+
+	var response AddLabelsToLabelableResponse
+	responseBytes, err := c.RunGraphQLQueryWithVariables(mutation, variables)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add labels: %w", err)
+	}
+	if err := Unmarshal(responseBytes, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse add labels response: %w", err)
+	}
+
+	return &response.Data.AddLabelsToLabelable.Labelable, nil
+}
+
+// RemoveLabelsFromItem removes labels from a single item
+func (c *GitHubClient) RemoveLabelsFromItem(itemID string, labelIDs []string) (*LabelableInfo, error) {
+	mutation := AllLabelFragments + `
+	mutation($input: RemoveLabelsFromLabelableInput!) {
+		removeLabelsFromLabelable(input: $input) {
+			labelable {
+				...LabelableFields
+			}
+		}
+	}`
+
+	variables := map[string]interface{}{
+		"input": map[string]interface{}{
+			"labelableId": itemID,
+			"labelIds":    labelIDs,
+		},
+	}
+
+	var response RemoveLabelsFromLabelableResponse
+	responseBytes, err := c.RunGraphQLQueryWithVariables(mutation, variables)
+	if err != nil {
+		return nil, fmt.Errorf("failed to remove labels: %w", err)
+	}
+	if err := Unmarshal(responseBytes, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse remove labels response: %w", err)
+	}
+
+	return &response.Data.RemoveLabelsFromLabelable.Labelable, nil
+}
+
+// GetPRWithLinkedIssues fetches a PR with its linked issues
+func (c *GitHubClient) GetPRWithLinkedIssues(prNumber int) (*PRWithLinkedIssues, error) {
+	query := LabelFragment + `
+	query($owner: String!, $repo: String!, $prNumber: Int!) {
+		repository(owner: $owner, name: $repo) {
+			pullRequest(number: $prNumber) {
+				id
+				number
+				title
+				labels(first: 100) {
+					nodes {
+						...LabelFields
+					}
+				}
+				closingIssuesReferences(first: 10) {
+					nodes {
+						number
+						labels(first: 100) {
+							nodes {
+								...LabelFields
+							}
+						}
+					}
+				}
+			}
+		}
+	}`
+
+	variables := map[string]interface{}{
+		"owner":    c.Owner,
+		"repo":     c.Repo,
+		"prNumber": prNumber,
+	}
+
+	var response GetPRWithLinkedIssuesResponse
+	responseBytes, err := c.RunGraphQLQueryWithVariables(query, variables)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch PR with linked issues: %w", err)
+	}
+	if err := Unmarshal(responseBytes, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse PR with linked issues response: %w", err)
+	}
+
+	return &response.Data.Repository.PullRequest, nil
 }

--- a/gh-helper/graphql_fragments.go
+++ b/gh-helper/graphql_fragments.go
@@ -208,6 +208,39 @@ fragment CommitWithStatusFields on Commit {
   }
 }`
 
+	// Label fragments
+	LabelFragment = `
+fragment LabelFields on Label {
+  id
+  name
+}`
+
+	LabelableFragment = `
+fragment LabelableFields on Labelable {
+  ... on Issue {
+    id
+    number
+    title
+    __typename
+    labels(first: 100) {
+      nodes {
+        ...LabelFields
+      }
+    }
+  }
+  ... on PullRequest {
+    id
+    number
+    title
+    __typename
+    labels(first: 100) {
+      nodes {
+        ...LabelFields
+      }
+    }
+  }
+}`
+
 	// Combined fragments for reuse
 	AllReviewFragments = PageInfoFragment + ReviewCommentFragment + ReviewFragment + ReviewConnectionFragment + PRMetadataFragment
 
@@ -215,9 +248,11 @@ fragment CommitWithStatusFields on Commit {
 
 	AllStatusFragments = StatusCheckRollupFragment + CommitWithStatusFragment
 
+	AllLabelFragments = LabelFragment + LabelableFragment
+
 	AllFragments = PageInfoFragment + ReviewCommentFragment + ReviewFragment + ReviewConnectionFragment + 
 		PRMetadataFragment + ThreadCommentFragment + ThreadFragment + ThreadConnectionFragment + 
-		StatusCheckRollupFragment + CommitWithStatusFragment
+		StatusCheckRollupFragment + CommitWithStatusFragment + LabelFragment + LabelableFragment
 )
 
 // Conversion functions between fragment types and domain types

--- a/gh-helper/graphql_types.go
+++ b/gh-helper/graphql_types.go
@@ -316,6 +316,153 @@ type ReviewMonitorResponse struct {
 }
 
 // =============================================================================
+// Label Operation Types
+// =============================================================================
+
+// Label represents a GitHub label
+type Label struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// LabelableInfo represents common fields for Issues and PRs
+type LabelableInfo struct {
+	ID       string `json:"id"`
+	Number   int    `json:"number"`
+	Title    string `json:"title"`
+	TypeName string `json:"__typename"`
+	Labels   struct {
+		Nodes []Label `json:"nodes"`
+	} `json:"labels"`
+}
+
+// GetLabelIDsVariables for fetching label IDs by name
+type GetLabelIDsVariables struct {
+	Owner  string   `json:"owner"`
+	Repo   string   `json:"repo"`
+	Labels []string `json:"labels"`
+}
+
+// GetLabelIDsResponse contains label ID mapping
+type GetLabelIDsResponse struct {
+	Data struct {
+		Repository struct {
+			Labels struct {
+				Nodes []Label `json:"nodes"`
+			} `json:"labels"`
+		} `json:"repository"`
+	} `json:"data"`
+}
+
+// AddLabelsToLabelableInput for adding labels mutation
+type AddLabelsToLabelableInput struct {
+	ClientMutationID *string  `json:"clientMutationId,omitempty"`
+	LabelableID      string   `json:"labelableId"`
+	LabelIDs         []string `json:"labelIds"`
+}
+
+// AddLabelsToLabelableVariables for the mutation
+type AddLabelsToLabelableVariables struct {
+	Input AddLabelsToLabelableInput `json:"input"`
+}
+
+// AddLabelsToLabelableResponse from the mutation
+type AddLabelsToLabelableResponse struct {
+	Data struct {
+		AddLabelsToLabelable struct {
+			Labelable LabelableInfo `json:"labelable"`
+		} `json:"addLabelsToLabelable"`
+	} `json:"data"`
+}
+
+// RemoveLabelsFromLabelableInput for removing labels mutation
+type RemoveLabelsFromLabelableInput struct {
+	ClientMutationID *string  `json:"clientMutationId,omitempty"`
+	LabelableID      string   `json:"labelableId"`
+	LabelIDs         []string `json:"labelIds"`
+}
+
+// RemoveLabelsFromLabelableVariables for the mutation
+type RemoveLabelsFromLabelableVariables struct {
+	Input RemoveLabelsFromLabelableInput `json:"input"`
+}
+
+// RemoveLabelsFromLabelableResponse from the mutation
+type RemoveLabelsFromLabelableResponse struct {
+	Data struct {
+		RemoveLabelsFromLabelable struct {
+			Labelable LabelableInfo `json:"labelable"`
+		} `json:"removeLabelsFromLabelable"`
+	} `json:"data"`
+}
+
+// GetLabelableInfoVariables for fetching item details
+type GetLabelableInfoVariables struct {
+	Owner  string `json:"owner"`
+	Repo   string `json:"repo"`
+	Number int    `json:"number"`
+}
+
+// GetLabelableInfoResponse contains item details
+type GetLabelableInfoResponse struct {
+	Data struct {
+		Repository struct {
+			Issue       *LabelableInfo `json:"issue"`
+			PullRequest *LabelableInfo `json:"pullRequest"`
+		} `json:"repository"`
+	} `json:"data"`
+}
+
+// SearchItemsByTitleVariables for searching by pattern
+type SearchItemsByTitleVariables struct {
+	Query string `json:"query"`
+	Limit int    `json:"limit"`
+}
+
+// SearchItemsByTitleResponse contains search results
+type SearchItemsByTitleResponse struct {
+	Data struct {
+		Search struct {
+			Nodes []LabelableInfo `json:"nodes"`
+		} `json:"search"`
+	} `json:"data"`
+}
+
+// PRWithLinkedIssues for add-from-issues command
+type PRWithLinkedIssues struct {
+	ID     string `json:"id"`
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	Labels struct {
+		Nodes []Label `json:"nodes"`
+	} `json:"labels"`
+	ClosingIssuesReferences struct {
+		Nodes []struct {
+			Number int `json:"number"`
+			Labels struct {
+				Nodes []Label `json:"nodes"`
+			} `json:"labels"`
+		} `json:"nodes"`
+	} `json:"closingIssuesReferences"`
+}
+
+// GetPRWithLinkedIssuesVariables for fetching PR with issues
+type GetPRWithLinkedIssuesVariables struct {
+	Owner    string `json:"owner"`
+	Repo     string `json:"repo"`
+	PRNumber int    `json:"prNumber"`
+}
+
+// GetPRWithLinkedIssuesResponse contains PR and linked issues
+type GetPRWithLinkedIssuesResponse struct {
+	Data struct {
+		Repository struct {
+			PullRequest PRWithLinkedIssues `json:"pullRequest"`
+		} `json:"repository"`
+	} `json:"data"`
+}
+
+// =============================================================================
 // Common Types
 // =============================================================================
 

--- a/gh-helper/labels.go
+++ b/gh-helper/labels.go
@@ -1,0 +1,546 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var labelsCmd = &cobra.Command{
+	Use:   "labels",
+	Short: "GitHub label operations for Issues and Pull Requests",
+	Long:  `Manage labels on GitHub Issues and Pull Requests with bulk operations support.`,
+}
+
+var addLabelsCmd = NewOperationalCommand(
+	"add <label>[,<label>...] [flags]",
+	"Add labels to multiple items",
+	`Add one or more labels to multiple PRs and/or Issues in a single operation.
+
+Examples:
+  # Add multiple labels to multiple items (auto-detect type)
+  gh-helper labels add bug,high-priority --items 254,267,238,245
+  
+  # Explicit type specification
+  gh-helper labels add enhancement --items issue/301,pull/302,340
+  
+  # Pattern-based labeling
+  gh-helper labels add enhancement --title-pattern "^feat:"`,
+	addLabels,
+)
+
+var removeLabelsCmd = NewOperationalCommand(
+	"remove <label>[,<label>...] [flags]",
+	"Remove labels from multiple items",
+	`Remove one or more labels from multiple PRs and/or Issues in a single operation.
+
+Examples:
+  # Remove multiple labels from multiple items
+  gh-helper labels remove needs-review,waiting-on-author --items 254,267,238,245
+  
+  # Remove with explicit type specification
+  gh-helper labels remove wip --items issue/301,pull/302`,
+	removeLabels,
+)
+
+var addFromIssuesCmd = NewOperationalCommand(
+	"add-from-issues [flags]",
+	"Add labels from linked issues to PR",
+	`Inherit labels from issues that a PR closes or references.
+
+Examples:
+  # Add labels from linked issues to a PR
+  gh-helper labels add-from-issues --pr 254
+  
+  # Dry-run to see what would be added
+  gh-helper labels add-from-issues --pr 254 --dry-run`,
+	addFromIssues,
+)
+
+func init() {
+	// Add flags for add command
+	addLabelsCmd.Flags().String("items", "", "Comma-separated list of items (e.g., 254,issue/238,pull/267)")
+	addLabelsCmd.Flags().String("title-pattern", "", "Regex pattern to match titles")
+	addLabelsCmd.Flags().Bool("dry-run", false, "Show what would be done without making changes")
+	addLabelsCmd.Flags().Bool("confirm", false, "Interactive confirmation for bulk operations")
+	addLabelsCmd.Flags().Bool("parallel", true, "Execute mutations concurrently")
+	addLabelsCmd.Flags().Int("max-concurrent", 5, "Maximum concurrent requests")
+
+	// Add flags for remove command
+	removeLabelsCmd.Flags().String("items", "", "Comma-separated list of items (e.g., 254,issue/238,pull/267)")
+	removeLabelsCmd.Flags().String("title-pattern", "", "Regex pattern to match titles")
+	removeLabelsCmd.Flags().Bool("dry-run", false, "Show what would be done without making changes")
+	removeLabelsCmd.Flags().Bool("confirm", false, "Interactive confirmation for bulk operations")
+	removeLabelsCmd.Flags().Bool("parallel", true, "Execute mutations concurrently")
+	removeLabelsCmd.Flags().Int("max-concurrent", 5, "Maximum concurrent requests")
+
+	// Add flags for add-from-issues command
+	addFromIssuesCmd.Flags().Int("pr", 0, "Pull request number")
+	if err := addFromIssuesCmd.MarkFlagRequired("pr"); err != nil {
+		panic(fmt.Sprintf("failed to mark pr flag as required: %v", err))
+	}
+	addFromIssuesCmd.Flags().Bool("dry-run", false, "Show what would be added without making changes")
+
+	// Add subcommands
+	labelsCmd.AddCommand(addLabelsCmd, removeLabelsCmd, addFromIssuesCmd)
+}
+
+// LabelOperationResult represents the result of a label operation
+type LabelOperationResult struct {
+	Type          string   `json:"type"`
+	Number        int      `json:"number"`
+	Operation     string   `json:"operation"`
+	LabelsAdded   []string `json:"labelsAdded,omitempty"`
+	LabelsRemoved []string `json:"labelsRemoved,omitempty"`
+	CurrentLabels []string `json:"currentLabels"`
+	Status        string   `json:"status"`
+	Error         string   `json:"error,omitempty"`
+}
+
+// LabelOperationSummary represents the summary of bulk operations
+type LabelOperationSummary struct {
+	LabelsModified []LabelOperationResult `json:"labelsModified"`
+	Summary        struct {
+		TotalItems      int      `json:"totalItems"`
+		LabelsModified  []string `json:"labelsModified"`
+		Successful      int      `json:"successful"`
+		Failed          int      `json:"failed"`
+	} `json:"summary"`
+}
+
+// ParseItemSpec parses an item specification like "254", "issue/238", "pull/267"
+func ParseItemSpec(spec string) (itemType string, number int, err error) {
+	spec = strings.TrimSpace(spec)
+	
+	// Check for explicit type specification
+	if strings.HasPrefix(spec, "issue/") {
+		itemType = "Issue"
+		_, err = fmt.Sscanf(spec, "issue/%d", &number)
+		return
+	}
+	if strings.HasPrefix(spec, "pull/") || strings.HasPrefix(spec, "pr/") {
+		itemType = "PullRequest"
+		if strings.HasPrefix(spec, "pull/") {
+			_, err = fmt.Sscanf(spec, "pull/%d", &number)
+		} else {
+			_, err = fmt.Sscanf(spec, "pr/%d", &number)
+		}
+		return
+	}
+	
+	// Plain number - type will be auto-detected
+	_, err = fmt.Sscanf(spec, "%d", &number)
+	return "", number, err
+}
+
+func addLabels(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("requires at least one label argument")
+	}
+
+	labels := strings.Split(args[0], ",")
+	for i := range labels {
+		labels[i] = strings.TrimSpace(labels[i])
+	}
+
+	items, _ := cmd.Flags().GetString("items")
+	titlePattern, _ := cmd.Flags().GetString("title-pattern")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	parallel, _ := cmd.Flags().GetBool("parallel")
+	maxConcurrent, _ := cmd.Flags().GetInt("max-concurrent")
+
+	if items == "" && titlePattern == "" {
+		return fmt.Errorf("either --items or --title-pattern must be specified")
+	}
+
+	client := NewGitHubClient(owner, repo)
+
+	// Get repository info
+	repoID, err := client.getRepositoryID()
+	if err != nil {
+		return err
+	}
+
+	// Get label IDs
+	labelMap, err := client.GetLabelIDs(labels)
+	if err != nil {
+		return err
+	}
+
+	var labelIDs []string
+	for _, label := range labels {
+		if id, ok := labelMap[label]; ok {
+			labelIDs = append(labelIDs, id)
+		} else {
+			return fmt.Errorf("label '%s' not found in repository", label)
+		}
+	}
+
+	var itemsToProcess []ItemToLabel
+
+	// Process --items flag
+	if items != "" {
+		itemSpecs := strings.Split(items, ",")
+		for _, spec := range itemSpecs {
+			itemType, number, err := ParseItemSpec(spec)
+			if err != nil {
+				return fmt.Errorf("invalid item specification '%s': %v", spec, err)
+			}
+			
+			// Get item info (including type detection if needed)
+			item, err := client.GetLabelableInfo(repoID, itemType, number)
+			if err != nil {
+				return fmt.Errorf("failed to get item %s: %v", spec, err)
+			}
+			
+			itemsToProcess = append(itemsToProcess, ItemToLabel{
+				ID:     item.ID,
+				Number: item.Number,
+				Type:   item.TypeName,
+				Title:  item.Title,
+			})
+		}
+	}
+
+	// Process --title-pattern flag
+	if titlePattern != "" {
+		re, err := regexp.Compile(titlePattern)
+		if err != nil {
+			return fmt.Errorf("invalid regex pattern: %v", err)
+		}
+
+		// Search for items matching the pattern
+		matchingItems, err := client.SearchItemsByTitle(repoID, re)
+		if err != nil {
+			return err
+		}
+
+		itemsToProcess = append(itemsToProcess, matchingItems...)
+	}
+
+	if len(itemsToProcess) == 0 {
+		fmt.Println("No items found to process")
+		return nil
+	}
+
+	// Remove duplicates
+	seen := make(map[string]bool)
+	var uniqueItems []ItemToLabel
+	for _, item := range itemsToProcess {
+		if !seen[item.ID] {
+			seen[item.ID] = true
+			uniqueItems = append(uniqueItems, item)
+		}
+	}
+	itemsToProcess = uniqueItems
+
+	if dryRun {
+		fmt.Printf("Would add labels %v to %d items:\n", labels, len(itemsToProcess))
+		for _, item := range itemsToProcess {
+			fmt.Printf("  - %s #%d: %s\n", item.Type, item.Number, item.Title)
+		}
+		return nil
+	}
+
+	// Execute label additions
+	results := ExecuteParallel(
+		itemsToProcess,
+		func(item ItemToLabel) (LabelOperationResult, error) {
+			result := LabelOperationResult{
+				Type:      item.Type,
+				Number:    item.Number,
+				Operation: "add",
+			}
+
+			updatedItem, err := client.AddLabelsToItem(item.ID, labelIDs)
+			if err != nil {
+				result.Status = "failed"
+				result.Error = err.Error()
+				return result, nil
+			}
+
+			result.Status = "success"
+			result.LabelsAdded = labels
+			result.CurrentLabels = extractLabelNames(updatedItem.Labels.Nodes)
+			return result, nil
+		},
+		parallel,
+		maxConcurrent,
+	)
+
+	// Prepare output
+	summary := LabelOperationSummary{}
+	summary.Summary.TotalItems = len(results)
+	summary.Summary.LabelsModified = labels
+	
+	for _, result := range results {
+		summary.LabelsModified = append(summary.LabelsModified, result)
+		if result.Status == "success" {
+			summary.Summary.Successful++
+		} else {
+			summary.Summary.Failed++
+		}
+	}
+
+	return EncodeOutput(os.Stdout, ResolveFormat(cmd), summary)
+}
+
+func removeLabels(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("requires at least one label argument")
+	}
+
+	labels := strings.Split(args[0], ",")
+	for i := range labels {
+		labels[i] = strings.TrimSpace(labels[i])
+	}
+
+	items, _ := cmd.Flags().GetString("items")
+	titlePattern, _ := cmd.Flags().GetString("title-pattern")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	parallel, _ := cmd.Flags().GetBool("parallel")
+	maxConcurrent, _ := cmd.Flags().GetInt("max-concurrent")
+
+	if items == "" && titlePattern == "" {
+		return fmt.Errorf("either --items or --title-pattern must be specified")
+	}
+
+	client := NewGitHubClient(owner, repo)
+
+	// Get repository info
+	repoID, err := client.getRepositoryID()
+	if err != nil {
+		return err
+	}
+
+	// Get label IDs
+	labelMap, err := client.GetLabelIDs(labels)
+	if err != nil {
+		return err
+	}
+
+	var labelIDs []string
+	for _, label := range labels {
+		if id, ok := labelMap[label]; ok {
+			labelIDs = append(labelIDs, id)
+		} else {
+			// Skip non-existent labels for remove operation
+			continue
+		}
+	}
+
+	if len(labelIDs) == 0 {
+		fmt.Println("No valid labels to remove")
+		return nil
+	}
+
+	var itemsToProcess []ItemToLabel
+
+	// Process --items flag
+	if items != "" {
+		itemSpecs := strings.Split(items, ",")
+		for _, spec := range itemSpecs {
+			itemType, number, err := ParseItemSpec(spec)
+			if err != nil {
+				return fmt.Errorf("invalid item specification '%s': %v", spec, err)
+			}
+			
+			// Get item info (including type detection if needed)
+			item, err := client.GetLabelableInfo(repoID, itemType, number)
+			if err != nil {
+				return fmt.Errorf("failed to get item %s: %v", spec, err)
+			}
+			
+			itemsToProcess = append(itemsToProcess, ItemToLabel{
+				ID:     item.ID,
+				Number: item.Number,
+				Type:   item.TypeName,
+				Title:  item.Title,
+			})
+		}
+	}
+
+	// Process --title-pattern flag
+	if titlePattern != "" {
+		re, err := regexp.Compile(titlePattern)
+		if err != nil {
+			return fmt.Errorf("invalid regex pattern: %v", err)
+		}
+
+		// Search for items matching the pattern
+		matchingItems, err := client.SearchItemsByTitle(repoID, re)
+		if err != nil {
+			return err
+		}
+
+		itemsToProcess = append(itemsToProcess, matchingItems...)
+	}
+
+	if len(itemsToProcess) == 0 {
+		fmt.Println("No items found to process")
+		return nil
+	}
+
+	// Remove duplicates
+	seen := make(map[string]bool)
+	var uniqueItems []ItemToLabel
+	for _, item := range itemsToProcess {
+		if !seen[item.ID] {
+			seen[item.ID] = true
+			uniqueItems = append(uniqueItems, item)
+		}
+	}
+	itemsToProcess = uniqueItems
+
+	if dryRun {
+		fmt.Printf("Would remove labels %v from %d items:\n", labels, len(itemsToProcess))
+		for _, item := range itemsToProcess {
+			fmt.Printf("  - %s #%d: %s\n", item.Type, item.Number, item.Title)
+		}
+		return nil
+	}
+
+	// Execute label removals
+	results := ExecuteParallel(
+		itemsToProcess,
+		func(item ItemToLabel) (LabelOperationResult, error) {
+			result := LabelOperationResult{
+				Type:      item.Type,
+				Number:    item.Number,
+				Operation: "remove",
+			}
+
+			updatedItem, err := client.RemoveLabelsFromItem(item.ID, labelIDs)
+			if err != nil {
+				result.Status = "failed"
+				result.Error = err.Error()
+				return result, nil
+			}
+
+			result.Status = "success"
+			result.LabelsRemoved = labels
+			result.CurrentLabels = extractLabelNames(updatedItem.Labels.Nodes)
+			return result, nil
+		},
+		parallel,
+		maxConcurrent,
+	)
+
+	// Prepare output
+	summary := LabelOperationSummary{}
+	summary.Summary.TotalItems = len(results)
+	summary.Summary.LabelsModified = labels
+	
+	for _, result := range results {
+		summary.LabelsModified = append(summary.LabelsModified, result)
+		if result.Status == "success" {
+			summary.Summary.Successful++
+		} else {
+			summary.Summary.Failed++
+		}
+	}
+
+	return EncodeOutput(os.Stdout, ResolveFormat(cmd), summary)
+}
+
+func addFromIssues(cmd *cobra.Command, args []string) error {
+	prNumber, _ := cmd.Flags().GetInt("pr")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+	client := NewGitHubClient(owner, repo)
+
+	// Get PR info with linked issues
+	pr, err := client.GetPRWithLinkedIssues(prNumber)
+	if err != nil {
+		return fmt.Errorf("failed to get PR %d: %v", prNumber, err)
+	}
+
+	// Collect all unique labels from linked issues
+	labelSet := make(map[string]bool)
+	existingLabels := make(map[string]bool)
+	
+	// Track existing labels on PR
+	for _, label := range pr.Labels.Nodes {
+		existingLabels[label.Name] = true
+	}
+
+	// Collect labels from linked issues
+	for _, issue := range pr.ClosingIssuesReferences.Nodes {
+		for _, label := range issue.Labels.Nodes {
+			if !existingLabels[label.Name] {
+				labelSet[label.Name] = true
+			}
+		}
+	}
+
+	// Convert to slice
+	var labelsToAdd []string
+	for label := range labelSet {
+		labelsToAdd = append(labelsToAdd, label)
+	}
+
+	if len(labelsToAdd) == 0 {
+		fmt.Printf("PR #%d already has all labels from its linked issues\n", prNumber)
+		return nil
+	}
+
+	if dryRun {
+		fmt.Printf("Would add the following labels to PR #%d:\n", prNumber)
+		for _, label := range labelsToAdd {
+			fmt.Printf("  - %s\n", label)
+		}
+		fmt.Printf("\nLabels inherited from %d linked issue(s)\n", len(pr.ClosingIssuesReferences.Nodes))
+		return nil
+	}
+
+	// Get label IDs
+	labelMap, err := client.GetLabelIDs(labelsToAdd)
+	if err != nil {
+		return err
+	}
+
+	var labelIDs []string
+	for _, label := range labelsToAdd {
+		if id, ok := labelMap[label]; ok {
+			labelIDs = append(labelIDs, id)
+		}
+	}
+
+	// Add labels to PR
+	updatedPR, err := client.AddLabelsToItem(pr.ID, labelIDs)
+	if err != nil {
+		return fmt.Errorf("failed to add labels: %v", err)
+	}
+
+	// Prepare output
+	result := LabelOperationResult{
+		Type:          "PullRequest",
+		Number:        prNumber,
+		Operation:     "add-from-issues",
+		LabelsAdded:   labelsToAdd,
+		CurrentLabels: extractLabelNames(updatedPR.Labels.Nodes),
+		Status:        "success",
+	}
+
+	return EncodeOutput(os.Stdout, ResolveFormat(cmd), result)
+}
+
+// Helper function to extract label names from nodes
+func extractLabelNames(nodes []Label) []string {
+	names := make([]string, len(nodes))
+	for i, node := range nodes {
+		names[i] = node.Name
+	}
+	return names
+}
+
+// ItemToLabel represents an item to be labeled
+type ItemToLabel struct {
+	ID     string
+	Number int
+	Type   string
+	Title  string
+}

--- a/gh-helper/labels.go
+++ b/gh-helper/labels.go
@@ -123,11 +123,11 @@ func ParseItemSpec(spec string) (itemType string, number int, err error) {
 	}
 	if strings.HasPrefix(spec, "pull/") || strings.HasPrefix(spec, "pr/") {
 		itemType = "PullRequest"
-		if strings.HasPrefix(spec, "pull/") {
-			_, err = fmt.Sscanf(spec, "pull/%d", &number)
-		} else {
-			_, err = fmt.Sscanf(spec, "pr/%d", &number)
+		prefix := "pull/"
+		if strings.HasPrefix(spec, "pr/") {
+			prefix = "pr/"
 		}
+		_, err = fmt.Sscanf(spec, prefix+"%d", &number)
 		return
 	}
 	

--- a/gh-helper/main.go
+++ b/gh-helper/main.go
@@ -261,7 +261,7 @@ func init() {
 	// Add subcommands
 	reviewsCmd.AddCommand(fetchReviewsCmd, waitReviewsCmd)
 	threadsCmd.AddCommand(showThreadCmd, replyThreadsCmd, resolveThreadCmd)
-	rootCmd.AddCommand(reviewsCmd, threadsCmd)
+	rootCmd.AddCommand(reviewsCmd, threadsCmd, labelsCmd)
 }
 
 func main() {

--- a/gh-helper/parallel.go
+++ b/gh-helper/parallel.go
@@ -6,6 +6,7 @@ import (
 
 // ExecuteParallel executes a function for each item in parallel with configurable concurrency
 // T is the input type, R is the result type
+// Note: This function ignores errors. Use ExecuteParallelWithErrors when error handling is needed.
 func ExecuteParallel[T any, R any](items []T, fn func(T) (R, error), parallel bool, maxConcurrent int) []R {
 	results := make([]R, len(items))
 	

--- a/gh-helper/parallel.go
+++ b/gh-helper/parallel.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"sync"
+)
+
+// ExecuteParallel executes a function for each item in parallel with configurable concurrency
+// T is the input type, R is the result type
+func ExecuteParallel[T any, R any](items []T, fn func(T) (R, error), parallel bool, maxConcurrent int) []R {
+	results := make([]R, len(items))
+	
+	if !parallel || maxConcurrent <= 1 || len(items) <= 1 {
+		// Sequential execution
+		for i, item := range items {
+			result, _ := fn(item)
+			results[i] = result
+		}
+		return results
+	}
+
+	// Parallel execution with semaphore for concurrency control
+	sem := make(chan struct{}, maxConcurrent)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+
+	for i, item := range items {
+		wg.Add(1)
+		go func(idx int, item T) {
+			defer wg.Done()
+			
+			// Acquire semaphore
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			
+			// Execute function
+			result, _ := fn(item)
+			
+			// Store result safely
+			mu.Lock()
+			results[idx] = result
+			mu.Unlock()
+		}(i, item)
+	}
+
+	wg.Wait()
+	return results
+}
+
+// ParallelResult wraps a result with its index and error
+type ParallelResult[T any] struct {
+	Index  int
+	Result T
+	Error  error
+}
+
+// ExecuteParallelWithErrors executes a function for each item in parallel and returns results with errors
+func ExecuteParallelWithErrors[T any, R any](items []T, fn func(T) (R, error), parallel bool, maxConcurrent int) []ParallelResult[R] {
+	results := make([]ParallelResult[R], len(items))
+	
+	if !parallel || maxConcurrent <= 1 || len(items) <= 1 {
+		// Sequential execution
+		for i, item := range items {
+			result, err := fn(item)
+			results[i] = ParallelResult[R]{
+				Index:  i,
+				Result: result,
+				Error:  err,
+			}
+		}
+		return results
+	}
+
+	// Parallel execution with semaphore for concurrency control
+	sem := make(chan struct{}, maxConcurrent)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+
+	for i, item := range items {
+		wg.Add(1)
+		go func(idx int, item T) {
+			defer wg.Done()
+			
+			// Acquire semaphore
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			
+			// Execute function
+			result, err := fn(item)
+			
+			// Store result safely
+			mu.Lock()
+			results[idx] = ParallelResult[R]{
+				Index:  idx,
+				Result: result,
+				Error:  err,
+			}
+			mu.Unlock()
+		}(i, item)
+	}
+
+	wg.Wait()
+	return results
+}


### PR DESCRIPTION
## Summary
- Implements bulk label operations with n:m support for PRs and Issues
- Adds `labels add`, `labels remove`, and `labels add-from-issues` commands
- Includes reusable parallel execution utility for future bulk operations

## Implementation Details

### Key Features
- **Bulk operations**: Add/remove multiple labels to/from multiple items in one command
- **Auto-detection**: Plain numbers automatically detect if they're Issues or PRs
- **Explicit specification**: Support `issue/N` and `pull/N` format for clarity
- **Pattern matching**: Add labels based on title regex patterns
- **Parallel execution**: Configurable concurrency with `--parallel` and `--max-concurrent`
- **Dry-run mode**: Preview operations before execution

### Technical Approach
- Uses single GraphQL mutations executed multiple times (not dynamic queries)
- Implements generic `ExecuteParallel[T, R]` utility for reusability
- Properly uses GraphQL fragments for all label operations
- Follows existing codebase patterns (common Unmarshal, no direct json/yaml)

### Example Usage
```bash
# Add multiple labels to multiple items
gh-helper labels add bug,high-priority --items 254,267,238,245

# Remove labels with explicit type
gh-helper labels remove wip --items issue/301,pull/302

# Add labels from linked issues
gh-helper labels add-from-issues --pr 254

# Pattern-based labeling
gh-helper labels add enhancement --title-pattern "^feat:"
```

## Test Plan
- [x] Build succeeds (`make build`)
- [x] All tests pass (`make test`)
- [x] Linting passes (`make lint`)
- [x] Full check passes (`make check`)
- [ ] Manual testing of label operations
- [ ] Verify parallel execution works correctly
- [ ] Test dry-run mode behavior

Closes #7

🤖 Generated with [Claude Code](https://claude.ai/code)