### PR TITLE
fix: add error handling for command flag parsing

### DIFF
--- a/gh-helper/issues.go
+++ b/gh-helper/issues.go
@@ -106,14 +106,38 @@ type ParentIssueInfo struct {
 
 func createIssue(cmd *cobra.Command, args []string) error {
 	// Get flags
-	title, _ := cmd.Flags().GetString("title")
-	body, _ := cmd.Flags().GetString("body")
-	bodyFile, _ := cmd.Flags().GetString("body-file")
-	labels, _ := cmd.Flags().GetStringSlice("label")
-	assignees, _ := cmd.Flags().GetStringSlice("assignee")
-	milestone, _ := cmd.Flags().GetString("milestone")
-	project, _ := cmd.Flags().GetString("project")
-	parentNumber, _ := cmd.Flags().GetInt("parent")
+	title, err := cmd.Flags().GetString("title")
+	if err != nil {
+		return fmt.Errorf("failed to get 'title' flag: %w", err)
+	}
+	body, err := cmd.Flags().GetString("body")
+	if err != nil {
+		return fmt.Errorf("failed to get 'body' flag: %w", err)
+	}
+	bodyFile, err := cmd.Flags().GetString("body-file")
+	if err != nil {
+		return fmt.Errorf("failed to get 'body-file' flag: %w", err)
+	}
+	labels, err := cmd.Flags().GetStringSlice("label")
+	if err != nil {
+		return fmt.Errorf("failed to get 'label' flag: %w", err)
+	}
+	assignees, err := cmd.Flags().GetStringSlice("assignee")
+	if err != nil {
+		return fmt.Errorf("failed to get 'assignee' flag: %w", err)
+	}
+	milestone, err := cmd.Flags().GetString("milestone")
+	if err != nil {
+		return fmt.Errorf("failed to get 'milestone' flag: %w", err)
+	}
+	project, err := cmd.Flags().GetString("project")
+	if err != nil {
+		return fmt.Errorf("failed to get 'project' flag: %w", err)
+	}
+	parentNumber, err := cmd.Flags().GetInt("parent")
+	if err != nil {
+		return fmt.Errorf("failed to get 'parent' flag: %w", err)
+	}
 
 	// Handle body from file
 	if bodyFile != "" {
@@ -619,7 +643,10 @@ func linkParent(cmd *cobra.Command, args []string) error {
 	}
 	
 	// Get parent from flag
-	parentNumber, _ := cmd.Flags().GetInt("parent")
+	parentNumber, err := cmd.Flags().GetInt("parent")
+	if err != nil {
+		return fmt.Errorf("failed to get 'parent' flag: %w", err)
+	}
 	
 	// Create GitHub client
 	client := NewGitHubClient(owner, repo)

--- a/gh-helper/labels.go
+++ b/gh-helper/labels.go
@@ -146,11 +146,26 @@ func addLabels(cmd *cobra.Command, args []string) error {
 		labels[i] = strings.TrimSpace(labels[i])
 	}
 
-	items, _ := cmd.Flags().GetString("items")
-	titlePattern, _ := cmd.Flags().GetString("title-pattern")
-	dryRun, _ := cmd.Flags().GetBool("dry-run")
-	parallel, _ := cmd.Flags().GetBool("parallel")
-	maxConcurrent, _ := cmd.Flags().GetInt("max-concurrent")
+	items, err := cmd.Flags().GetString("items")
+	if err != nil {
+		return fmt.Errorf("failed to get 'items' flag: %w", err)
+	}
+	titlePattern, err := cmd.Flags().GetString("title-pattern")
+	if err != nil {
+		return fmt.Errorf("failed to get 'title-pattern' flag: %w", err)
+	}
+	dryRun, err := cmd.Flags().GetBool("dry-run")
+	if err != nil {
+		return fmt.Errorf("failed to get 'dry-run' flag: %w", err)
+	}
+	parallel, err := cmd.Flags().GetBool("parallel")
+	if err != nil {
+		return fmt.Errorf("failed to get 'parallel' flag: %w", err)
+	}
+	maxConcurrent, err := cmd.Flags().GetInt("max-concurrent")
+	if err != nil {
+		return fmt.Errorf("failed to get 'max-concurrent' flag: %w", err)
+	}
 
 	if items == "" && titlePattern == "" {
 		return fmt.Errorf("either --items or --title-pattern must be specified")
@@ -298,11 +313,26 @@ func removeLabels(cmd *cobra.Command, args []string) error {
 		labels[i] = strings.TrimSpace(labels[i])
 	}
 
-	items, _ := cmd.Flags().GetString("items")
-	titlePattern, _ := cmd.Flags().GetString("title-pattern")
-	dryRun, _ := cmd.Flags().GetBool("dry-run")
-	parallel, _ := cmd.Flags().GetBool("parallel")
-	maxConcurrent, _ := cmd.Flags().GetInt("max-concurrent")
+	items, err := cmd.Flags().GetString("items")
+	if err != nil {
+		return fmt.Errorf("failed to get 'items' flag: %w", err)
+	}
+	titlePattern, err := cmd.Flags().GetString("title-pattern")
+	if err != nil {
+		return fmt.Errorf("failed to get 'title-pattern' flag: %w", err)
+	}
+	dryRun, err := cmd.Flags().GetBool("dry-run")
+	if err != nil {
+		return fmt.Errorf("failed to get 'dry-run' flag: %w", err)
+	}
+	parallel, err := cmd.Flags().GetBool("parallel")
+	if err != nil {
+		return fmt.Errorf("failed to get 'parallel' flag: %w", err)
+	}
+	maxConcurrent, err := cmd.Flags().GetInt("max-concurrent")
+	if err != nil {
+		return fmt.Errorf("failed to get 'max-concurrent' flag: %w", err)
+	}
 
 	if items == "" && titlePattern == "" {
 		return fmt.Errorf("either --items or --title-pattern must be specified")
@@ -447,8 +477,14 @@ func removeLabels(cmd *cobra.Command, args []string) error {
 }
 
 func addFromIssues(cmd *cobra.Command, args []string) error {
-	prNumber, _ := cmd.Flags().GetInt("pr")
-	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	prNumber, err := cmd.Flags().GetInt("pr")
+	if err != nil {
+		return fmt.Errorf("failed to get 'pr' flag: %w", err)
+	}
+	dryRun, err := cmd.Flags().GetBool("dry-run")
+	if err != nil {
+		return fmt.Errorf("failed to get 'dry-run' flag: %w", err)
+	}
 
 	client := NewGitHubClient(owner, repo)
 

--- a/gh-helper/releases.go
+++ b/gh-helper/releases.go
@@ -123,11 +123,26 @@ type LinkedIssue struct {
 
 func analyzeRelease(cmd *cobra.Command, args []string) error {
 	// Get flags
-	milestone, _ := cmd.Flags().GetString("milestone")
-	since, _ := cmd.Flags().GetString("since")
-	until, _ := cmd.Flags().GetString("until")
-	prRange, _ := cmd.Flags().GetString("pr-range")
-	includeDrafts, _ := cmd.Flags().GetBool("include-drafts")
+	milestone, err := cmd.Flags().GetString("milestone")
+	if err != nil {
+		return fmt.Errorf("failed to get 'milestone' flag: %w", err)
+	}
+	since, err := cmd.Flags().GetString("since")
+	if err != nil {
+		return fmt.Errorf("failed to get 'since' flag: %w", err)
+	}
+	until, err := cmd.Flags().GetString("until")
+	if err != nil {
+		return fmt.Errorf("failed to get 'until' flag: %w", err)
+	}
+	prRange, err := cmd.Flags().GetString("pr-range")
+	if err != nil {
+		return fmt.Errorf("failed to get 'pr-range' flag: %w", err)
+	}
+	includeDrafts, err := cmd.Flags().GetBool("include-drafts")
+	if err != nil {
+		return fmt.Errorf("failed to get 'include-drafts' flag: %w", err)
+	}
 
 	// Validate input - must specify exactly one filter
 	filters := 0
@@ -153,7 +168,6 @@ func analyzeRelease(cmd *cobra.Command, args []string) error {
 
 	// Fetch PRs based on filter
 	var prs []PRData
-	var err error
 
 	switch {
 	case milestone != "":


### PR DESCRIPTION
## Summary
- Add proper error checking for all `cmd.Flags().Get*()` calls
- Return descriptive errors when flag parsing fails  
- Fix variable shadowing in releases.go

## Problem
In PR #15, Gemini Code Assist identified that we're ignoring errors returned by flag parsing functions. This can hide bugs where a typo in a flag name would cause the flag's value to be silently discarded.

## Solution
Added explicit error handling for all flag parsing operations:
```go
title, err := cmd.Flags().GetString("title")
if err \!= nil {
    return fmt.Errorf("failed to get 'title' flag: %w", err)
}
```

## Impact
- Improved error detection during development
- Better user experience with clear error messages
- Prevents silent failures from typos in flag names

## Testing
- All tests pass (`make check`)
- No linting issues

Fixes #19