### PR TITLE
feat: add sub-issue management commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,11 +45,12 @@ make build              # Build gh-helper tool
 ./bin/gh-helper reviews wait <PR> --request-summary   # Request and wait for Gemini summary
 ./bin/gh-helper threads reply <ID1> <ID2> <ID3> --resolve  # Bulk reply to threads
 
-# Issue and sub-issue management
+## Issue and sub-issue management
 ./bin/gh-helper issues show <number>               # Show basic issue information
 ./bin/gh-helper issues show <number> --include-sub # Show issue with sub-issues and statistics
 ./bin/gh-helper issues edit <number> --parent <parent>  # Add issue as sub-issue
 ./bin/gh-helper issues edit <number> --parent <parent> --overwrite  # Move to new parent
+./bin/gh-helper issues edit <number> --unlink-parent  # Remove parent relationship
 ```
 
 ## Core Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,12 @@ make build              # Build gh-helper tool
 ./bin/gh-helper reviews wait <PR> --async --detailed  # Get comprehensive PR status
 ./bin/gh-helper reviews wait <PR> --request-summary   # Request and wait for Gemini summary
 ./bin/gh-helper threads reply <ID1> <ID2> <ID3> --resolve  # Bulk reply to threads
+
+# Issue and sub-issue management
+./bin/gh-helper issues show <number>               # Show basic issue information
+./bin/gh-helper issues show <number> --include-sub # Show issue with sub-issues and statistics
+./bin/gh-helper issues edit <number> --parent <parent>  # Add issue as sub-issue
+./bin/gh-helper issues edit <number> --parent <parent> --overwrite  # Move to new parent
 ```
 
 ## Core Architecture
@@ -269,24 +275,29 @@ This command helps identify:
 - PRs that should have 'ignore-for-release' label
 - Inconsistent labeling patterns
 
-### Issue Creation
-Create issues with advanced features:
+### Issue Management
+Create and manage issues with advanced features:
 ```bash
 # Create issue with labels and assignee
 ./bin/gh-helper issues create --title "Add feature X" --body "Description" --label enhancement --assignee @me
 
 # Create sub-issue linked to parent
 ./bin/gh-helper issues create --title "Subtask: Implement Y" --body "Details" --parent 123
+
+# View issue with sub-issues
+./bin/gh-helper issues show 248 --include-sub
+./bin/gh-helper issues show 248 --include-sub --detailed  # Includes details for each sub-issue
+
+# Manage parent-child relationships
+./bin/gh-helper issues edit 456 --parent 123              # Add as sub-issue
+./bin/gh-helper issues edit 456 --parent 789 --overwrite  # Move to different parent
+./bin/gh-helper issues link-parent 456 --parent 123       # Deprecated: use edit command
 ```
 
-### Issue Linking
-Create parent-child relationships between existing issues:
-```bash
-# Make issue #456 a sub-issue of #123
-./bin/gh-helper issues link-parent 456 --parent 123
-
-# Make issue #789 a sub-issue of #456
-./bin/gh-helper issues link-parent 789 --parent 456
-```
+This provides comprehensive issue management including:
+- Viewing issues with sub-issue hierarchies and completion statistics
+- Creating parent-child relationships between issues
+- Moving sub-issues between different parents
+- Tracking completion percentages for project management
 
 For detailed usage examples and API documentation, see the README.md file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ make build              # Build gh-helper tool
 ./bin/gh-helper reviews wait <PR> --request-summary   # Request and wait for Gemini summary
 ./bin/gh-helper threads reply <ID1> <ID2> <ID3> --resolve  # Bulk reply to threads
 
-## Issue and sub-issue management
+# Issue and sub-issue management
 ./bin/gh-helper issues show <number>               # Show basic issue information
 ./bin/gh-helper issues show <number> --include-sub # Show issue with sub-issues and statistics
 ./bin/gh-helper issues edit <number> --parent <parent>  # Add issue as sub-issue

--- a/gh-helper/graphql_fragments.go
+++ b/gh-helper/graphql_fragments.go
@@ -262,6 +262,37 @@ fragment LabelableFields on Labelable {
   }
 }`
 
+	// Issue fragments
+	IssueFieldsFragment = `
+fragment IssueFields on Issue {
+  number
+  title
+  state
+  body
+  url
+  createdAt
+  updatedAt
+  labels(first: 20) {
+    nodes {
+      name
+    }
+  }
+  assignees(first: 10) {
+    nodes {
+      login
+    }
+  }
+}`
+
+	SubIssueFieldsFragment = `
+fragment SubIssueFields on Issue {
+  id
+  number
+  title
+  state
+  closed
+}`
+
 	// Combined fragments for reuse
 	AllReviewFragments = PageInfoFragment + ReviewCommentFragment + ReviewFragment + ReviewConnectionFragment + PRMetadataFragment
 
@@ -271,9 +302,12 @@ fragment LabelableFields on Labelable {
 
 	AllLabelFragments = LabelFragment + LabelableFragment
 
+	AllIssueFragments = IssueFieldsFragment + SubIssueFieldsFragment
+
 	AllFragments = PageInfoFragment + ReviewCommentFragment + ReviewFragment + ReviewConnectionFragment + 
 		PRMetadataFragment + ThreadCommentFragment + ThreadFragment + ThreadConnectionFragment + 
-		StatusCheckRollupFragment + CommitWithStatusFragment + LabelFragment + LabelableFragment
+		StatusCheckRollupFragment + CommitWithStatusFragment + LabelFragment + LabelableFragment +
+		IssueFieldsFragment + SubIssueFieldsFragment
 )
 
 // Conversion functions between fragment types and domain types

--- a/gh-helper/graphql_fragments.go
+++ b/gh-helper/graphql_fragments.go
@@ -306,8 +306,7 @@ fragment SubIssueFields on Issue {
 
 	AllFragments = PageInfoFragment + ReviewCommentFragment + ReviewFragment + ReviewConnectionFragment + 
 		PRMetadataFragment + ThreadCommentFragment + ThreadFragment + ThreadConnectionFragment + 
-		StatusCheckRollupFragment + CommitWithStatusFragment + LabelFragment + LabelableFragment +
-		IssueFieldsFragment + SubIssueFieldsFragment
+		StatusCheckRollupFragment + CommitWithStatusFragment + AllLabelFragments + AllIssueFragments
 )
 
 // Conversion functions between fragment types and domain types

--- a/gh-helper/issues.go
+++ b/gh-helper/issues.go
@@ -573,36 +573,16 @@ func (c *GitHubClient) GetProjectID(name string) (string, error) {
 
 // GetIssueWithSubIssues fetches issue information with optional sub-issues
 func (c *GitHubClient) GetIssueWithSubIssues(number int, includeSub bool, detailed bool) (*IssueShowResult, error) {
-	// Use GraphQL @include directive for conditional field inclusion
-	query := `
+	// Build query with fragments
+	query := AllIssueFragments + `
 	query($owner: String!, $repo: String!, $number: Int!, $includeSub: Boolean!) {
 		repository(owner: $owner, name: $repo) {
 			issue(number: $number) {
-				number
-				title
-				state
-				body
-				url
-				createdAt
-				updatedAt
-				labels(first: 20) {
-					nodes {
-						name
-					}
-				}
-				assignees(first: 10) {
-					nodes {
-						login
-					}
-				}
+				...IssueFields
 				subIssues(first: 100) @include(if: $includeSub) {
 					totalCount
 					nodes {
-						id
-						number
-						title
-						state
-						closed
+						...SubIssueFields
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

This PR implements comprehensive sub-issue management features as requested in #23.

## Changes

### New Commands

1. **`issues show`** - Display issue information with optional sub-issue data
   - `--include-sub`: Include sub-issues list and completion statistics
   - `--detailed`: Include detailed information for each sub-issue

2. **`issues edit`** - Manage parent-child relationships (replaces `link-parent`)
   - `--parent <number>`: Set parent issue
   - `--overwrite`: Replace existing parent relationship
   - `--unlink-parent`: Remove parent relationship

### Implementation Details

- Added comprehensive type definitions for structured output
- Implemented `GetIssueWithSubIssues` with optimized GraphQL queries
- Added `SetIssueParent` and `UnlinkIssueParent` methods
- Follows existing YAML/JSON output patterns
- Deprecated `link-parent` command with migration guidance

### Example Usage

```bash
# View issue with sub-issues
./bin/gh-helper issues show 248 --include-sub

# Add issue as sub-issue
./bin/gh-helper issues edit 456 --parent 123

# Move sub-issue to different parent
./bin/gh-helper issues edit 456 --parent 789 --overwrite
```

## Test Results

- ✅ All tests pass (`make check`)
- ✅ Manual testing completed with test issues
- ✅ Documentation updated in CLAUDE.md

## Known Limitations

The `--unlink-parent` functionality has an issue with GitHub's GraphQL schema not exposing a direct `parentIssue` field. This would need further investigation for full implementation.

Fixes #23

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>