### PR TITLE
fix: add missing GraphQL variable declarations for labels command

### DIFF
--- a/gh-helper/github.go
+++ b/gh-helper/github.go
@@ -744,7 +744,13 @@ func (c *GitHubClient) GetLabelableInfo(repoID string, itemType string, number i
 	// Use $isIssue and $isPR to conditionally include issue or pullRequest fields
 	// based on the item type to avoid unnecessary queries
 	query := LabelFragment + `
-	query GetLabelableInfo($owner: String!, $repo: String!, $number: Int!, $isIssue: Boolean!, $isPR: Boolean!) {
+	query GetLabelableInfo(
+		$owner: String!    # repository owner
+		$repo: String!     # repository name
+		$number: Int!      # issue or PR number
+		$isIssue: Boolean! # flag to include issue fields
+		$isPR: Boolean!    # flag to include PR fields
+	) {
 		repository(owner: $owner, name: $repo) {
 			issue(number: $number) @include(if: $isIssue) {
 				id

--- a/gh-helper/github.go
+++ b/gh-helper/github.go
@@ -742,7 +742,7 @@ func (c *GitHubClient) GetLabelableInfo(repoID string, itemType string, number i
 	}
 
 	query := LabelFragment + `
-	query($owner: String!, $repo: String!, $number: Int!) {
+	query($owner: String!, $repo: String!, $number: Int!, $isIssue: Boolean!, $isPR: Boolean!) {
 		repository(owner: $owner, name: $repo) {
 			issue(number: $number) @include(if: $isIssue) {
 				id

--- a/gh-helper/github.go
+++ b/gh-helper/github.go
@@ -741,8 +741,10 @@ func (c *GitHubClient) GetLabelableInfo(repoID string, itemType string, number i
 		itemType = node.NodeType
 	}
 
+	// Use $isIssue and $isPR to conditionally include issue or pullRequest fields
+	// based on the item type to avoid unnecessary queries
 	query := LabelFragment + `
-	query($owner: String!, $repo: String!, $number: Int!, $isIssue: Boolean!, $isPR: Boolean!) {
+	query GetLabelableInfo($owner: String!, $repo: String!, $number: Int!, $isIssue: Boolean!, $isPR: Boolean!) {
 		repository(owner: $owner, name: $repo) {
 			issue(number: $number) @include(if: $isIssue) {
 				id


### PR DESCRIPTION
## Summary
- Fixed GraphQL error when using `gh-helper labels add` with pull requests
- Added missing `$isIssue` and `$isPR` variable declarations

## Problem
The `GetLabelableInfo` function was using `$isIssue` and `$isPR` variables in `@include` directives without declaring them in the query parameters. This caused the following error:
```
Error: failed to get item pull/328: failed to fetch item info: GraphQL error: Variable $isIssue is used by anonymous query but not declared
```

## Solution
Added the missing variable declarations to the GraphQL query signature:
```diff
-query($owner: String\!, $repo: String\!, $number: Int\!) {
+query($owner: String\!, $repo: String\!, $number: Int\!, $isIssue: Boolean\!, $isPR: Boolean\!) {
```

## Test
The fix can be tested with:
```bash
gh-helper labels add docs-dev,enhancement --items pull/328
```

🤖 Generated with Claude Code