### PR TITLE
feat: enhance issues edit with comprehensive sub-issue management (#36)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,7 @@ go install github.com/apstndb/gh-dev-tools/gh-helper@latest
 - **Pointer types required**: Use pointer structs to handle null responses properly
 - **@include directives**: Use for conditional field inclusion to optimize queries
 - **Fragment reuse**: Define fragments for commonly used field sets to avoid repetition
+- **Field name accuracy**: Always verify field names with `go tool github-schema` to avoid runtime errors
 
 ### Examples
 
@@ -356,6 +357,41 @@ query($owner: String!, $repo: String!, $number: Int!, $includeSub: Boolean!) {
 - Ensures consistent field selection
 - Makes queries more maintainable
 - Simplifies updates when field requirements change
+
+### Common Field Naming Mistakes
+
+**Issue parent field**:
+```graphql
+# CORRECT - The field is named 'parent'
+query {
+  issue(number: $number) {
+    parent {
+      id
+      number
+      title
+    }
+  }
+}
+
+# WRONG - These fields don't exist
+query {
+  issue(number: $number) {
+    parentIssue { id }     # ❌ GraphQL error: Field 'parentIssue' doesn't exist
+    parent_issue { id }    # ❌ GraphQL error: Field 'parent_issue' doesn't exist
+  }
+}
+```
+
+**How to verify field names**:
+```bash
+# Check available fields on Issue type
+go tool github-schema type Issue | grep -i parent
+
+# Get full field details
+go tool github-schema type Issue
+```
+
+**Best practice**: Before using any field name that seems intuitive but you haven't used before, always verify it exists in the schema. GitHub's GraphQL API doesn't always follow naming conventions you might expect.
 
 ## GitHub GraphQL Schema Introspection
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -457,7 +457,6 @@ Create and manage issues with advanced features:
 # Manage parent-child relationships
 ./bin/gh-helper issues edit 456 --parent 123              # Add as sub-issue
 ./bin/gh-helper issues edit 456 --parent 789 --overwrite  # Move to different parent
-./bin/gh-helper issues link-parent 456 --parent 123       # Deprecated: use edit command
 ```
 
 This provides comprehensive issue management including:

--- a/gh-helper/README.md
+++ b/gh-helper/README.md
@@ -134,8 +134,6 @@ issues edit <number> --parent 123              # Add as sub-issue of #123
 issues edit <number> --parent 456 --overwrite  # Move to different parent
 issues edit <number> --unlink-parent           # Remove parent relationship
 
-# Deprecated command (use edit instead)
-issues link-parent <number> --parent 123       # Use 'issues edit' instead
 ```
 
 **Sub-issue Statistics**: When using `--include-sub`, provides:
@@ -477,7 +475,6 @@ gh-helper issues show 248 --include-sub | gojq --yaml-input '
 | `scripts/dev/list-review-threads.sh` | `gh-helper reviews fetch [PR] --list-threads` |
 | `scripts/dev/review-reply.sh` | `gh-helper threads reply` |
 | Custom review waiting scripts | `gh-helper reviews wait` |
-| `gh-helper issues link-parent` | `gh-helper issues edit <number> --parent <parent>` |
 
 ## Output Format and Programmatic Usage
 

--- a/gh-helper/graphql_types.go
+++ b/gh-helper/graphql_types.go
@@ -463,6 +463,258 @@ type GetPRWithLinkedIssuesResponse struct {
 }
 
 // =============================================================================
+// Issue Types (GitHub GraphQL API types and custom types)
+// =============================================================================
+
+// IssueFields represents the common fields for Issue in GitHub GraphQL API
+type IssueFields struct {
+	ID     string `json:"id"`
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	URL    string `json:"url,omitempty"`   // Optional: not always queried
+	State  string `json:"state,omitempty"` // Optional: not always queried
+}
+
+// CreateIssueInput for GitHub GraphQL API createIssue mutation
+type CreateIssueInput struct {
+	ClientMutationID *string  `json:"clientMutationId,omitempty"`
+	RepositoryID     string   `json:"repositoryId"`
+	Title            string   `json:"title"`
+	Body             *string  `json:"body,omitempty"`
+	LabelIDs         []string `json:"labelIds,omitempty"`
+	AssigneeIDs      []string `json:"assigneeIds,omitempty"`
+	MilestoneID      *string  `json:"milestoneId,omitempty"`
+	ProjectIDs       []string `json:"projectIds,omitempty"`
+}
+
+// CreateIssueResponse from GitHub GraphQL API
+type CreateIssueResponse struct {
+	Data struct {
+		CreateIssue struct {
+			Issue struct {
+				ID        string `json:"id"`
+				Number    int    `json:"number"`
+				URL       string `json:"url"`
+				Title     string `json:"title"`
+				State     string `json:"state"`
+				Labels    struct {
+					Nodes []struct {
+						Name string `json:"name"`
+					} `json:"nodes"`
+				} `json:"labels"`
+				Assignees struct {
+					Nodes []struct {
+						Login string `json:"login"`
+					} `json:"nodes"`
+				} `json:"assignees"`
+				CreatedAt string `json:"createdAt"`
+			} `json:"issue"`
+		} `json:"createIssue"`
+	} `json:"data"`
+}
+
+// AddSubIssueInput for GitHub GraphQL API addSubIssue mutation
+type AddSubIssueInput struct {
+	ClientMutationID *string `json:"clientMutationId,omitempty"`
+	IssueID          string  `json:"issueId"`
+	SubIssueID       string  `json:"subIssueId"`
+}
+
+// AddSubIssueResponse from GitHub GraphQL API
+type AddSubIssueResponse struct {
+	Data struct {
+		AddSubIssue struct {
+			Issue IssueFields `json:"issue"` // GitHub API Issue type
+		} `json:"addSubIssue"`
+	} `json:"data"`
+}
+
+// RemoveSubIssueInput for GitHub GraphQL API removeSubIssue mutation
+type RemoveSubIssueInput struct {
+	ClientMutationID *string `json:"clientMutationId,omitempty"`
+	IssueID          string  `json:"issueId"`
+	SubIssueID       string  `json:"subIssueId"`
+}
+
+// RemoveSubIssueMutationResponse from GitHub GraphQL API
+type RemoveSubIssueMutationResponse struct {
+	Data struct {
+		RemoveSubIssue struct {
+			Issue IssueFields `json:"issue"` // GitHub API Issue type
+		} `json:"removeSubIssue"`
+	} `json:"data"`
+}
+
+// ReprioritizeSubIssueInput for GitHub GraphQL API reprioritizeSubIssue mutation
+type ReprioritizeSubIssueInput struct {
+	ClientMutationID *string `json:"clientMutationId,omitempty"`
+	IssueID          string  `json:"issueId"`
+	SubIssueID       string  `json:"subIssueId"`
+	AfterID          *string `json:"afterId,omitempty"`
+	BeforeID         *string `json:"beforeId,omitempty"`
+}
+
+// ReprioritizeSubIssueResponse from GitHub GraphQL API
+type ReprioritizeSubIssueResponse struct {
+	Data struct {
+		ReprioritizeSubIssue struct {
+			Issue IssueFields `json:"issue"` // GitHub API Issue type
+		} `json:"reprioritizeSubIssue"`
+	} `json:"data"`
+}
+
+// NodeQueryParentResponse for queries fetching parent issue info via node
+type NodeQueryParentResponse struct {
+	Data struct {
+		Node struct {
+			Parent *IssueFields `json:"parent"` // GitHub API Issue type (can be nil)
+		} `json:"node"`
+	} `json:"data"`
+}
+
+// GetRepositoryIssuesResponse for queries fetching two issues
+type GetRepositoryIssuesResponse struct {
+	Data struct {
+		Repository struct {
+			Child  *IssueFields `json:"child"`  // GitHub API Issue type
+			Parent *IssueFields `json:"parent"` // GitHub API Issue type
+		} `json:"repository"`
+	} `json:"data"`
+}
+
+// UserQueryResponse for fetching user information
+type UserQueryResponse struct {
+	Data struct {
+		User struct {
+			ID string `json:"id"`
+		} `json:"user"`
+	} `json:"data"`
+}
+
+// MilestoneQueryResponse for fetching milestone information
+type MilestoneQueryResponse struct {
+	Data struct {
+		Repository struct {
+			Milestones struct {
+				Nodes []struct {
+					ID    string `json:"id"`
+					Title string `json:"title"`
+				} `json:"nodes"`
+			} `json:"milestones"`
+		} `json:"repository"`
+	} `json:"data"`
+}
+
+// ProjectQueryResponse for fetching project information
+type ProjectQueryResponse struct {
+	Data struct {
+		Repository struct {
+			ProjectsV2 struct {
+				Nodes []struct {
+					ID    string `json:"id"`
+					Title string `json:"title"`
+				} `json:"nodes"`
+			} `json:"projectsV2"`
+		} `json:"repository"`
+	} `json:"data"`
+}
+
+// IssueWithSubIssuesResponse for queries fetching issue with sub-issues
+type IssueWithSubIssuesResponse struct {
+	Data struct {
+		Repository struct {
+			Issue *struct {
+				Number    int    `json:"number"`
+				Title     string `json:"title"`
+				State     string `json:"state"`
+				Body      string `json:"body"`
+				URL       string `json:"url"`
+				CreatedAt string `json:"createdAt"`
+				UpdatedAt string `json:"updatedAt"`
+				Labels    struct {
+					Nodes []struct {
+						Name string `json:"name"`
+					} `json:"nodes"`
+				} `json:"labels"`
+				Assignees struct {
+					Nodes []struct {
+						Login string `json:"login"`
+					} `json:"nodes"`
+				} `json:"assignees"`
+				SubIssues *struct {
+					TotalCount int `json:"totalCount"`
+					Nodes      []struct {
+						ID     string `json:"id"`
+						Number int    `json:"number"`
+						Title  string `json:"title"`
+						State  string `json:"state"`
+						Closed bool   `json:"closed"`
+					} `json:"nodes"`
+				} `json:"subIssues,omitempty"`
+			} `json:"issue"`
+		} `json:"repository"`
+	} `json:"data"`
+}
+
+// BatchSubIssueQueryResponse for batch operations on sub-issues
+type BatchSubIssueQueryResponse struct {
+	Data struct {
+		Repository map[string]*IssueFields `json:"repository"` // GitHub API Issue type
+	} `json:"data"`
+}
+
+// GetRepositoryIssueResponse for queries fetching a single issue
+type GetRepositoryIssueResponse struct {
+	Data struct {
+		Repository struct {
+			Issue *IssueFields `json:"issue"` // GitHub API Issue type
+		} `json:"repository"`
+	} `json:"data"`
+}
+
+// NodeQuerySubIssuesResponse for queries fetching sub-issues via node(id:)
+type NodeQuerySubIssuesResponse struct {
+	Data struct {
+		Node struct {
+			SubIssues struct {
+				Nodes []struct {
+					ID string `json:"id"`
+				} `json:"nodes"`
+			} `json:"subIssues"`
+		} `json:"node"`
+	} `json:"data"`
+}
+
+// IssueQueryResponse for simple issue queries with parent info
+type IssueQueryResponse struct {
+	Data struct {
+		Repository struct {
+			Issue *struct {
+				ID    string `json:"id"`
+				Title string `json:"title"`
+				URL   string `json:"url"`
+				State string `json:"state"`
+				Parent *struct {
+					ID     string `json:"id"`
+					Number int    `json:"number"`
+					Title  string `json:"title"`
+				} `json:"parent"`
+			} `json:"issue"`
+		} `json:"repository"`
+	} `json:"data"`
+}
+
+// AddSubIssueMutationResponse for addSubIssue mutation with two issues returned
+type AddSubIssueMutationResponse struct {
+	Data struct {
+		AddSubIssue struct {
+			Issue    IssueFields `json:"issue"`    // GitHub API Issue type (parent)
+			SubIssue IssueFields `json:"subIssue"` // GitHub API Issue type (child)
+		} `json:"addSubIssue"`
+	} `json:"data"`
+}
+
+// =============================================================================
 // Common Types
 // =============================================================================
 

--- a/gh-helper/issues.go
+++ b/gh-helper/issues.go
@@ -330,30 +330,7 @@ func createIssue(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create issue: %w", err)
 	}
 
-	var response struct {
-		Data struct {
-			CreateIssue struct {
-				Issue struct {
-					ID        string `json:"id"`
-					Number    int    `json:"number"`
-					URL       string `json:"url"`
-					Title     string `json:"title"`
-					State     string `json:"state"`
-					Labels    struct {
-						Nodes []struct {
-							Name string `json:"name"`
-						} `json:"nodes"`
-					} `json:"labels"`
-					Assignees struct {
-						Nodes []struct {
-							Login string `json:"login"`
-						} `json:"nodes"`
-					} `json:"assignees"`
-					CreatedAt string `json:"createdAt"`
-				} `json:"issue"`
-			} `json:"createIssue"`
-		} `json:"data"`
-	}
+	var response CreateIssueResponse
 
 	if err := json.Unmarshal(responseData, &response); err != nil {
 		return fmt.Errorf("failed to parse response: %w", err)
@@ -424,13 +401,7 @@ func (c *GitHubClient) GetRepositoryID() (string, error) {
 		return "", err
 	}
 
-	var response struct {
-		Data struct {
-			Repository struct {
-				ID string `json:"id"`
-			} `json:"repository"`
-		} `json:"data"`
-	}
+	var response RepositoryIDResponse
 
 	if err := json.Unmarshal(responseData, &response); err != nil {
 		return "", err
@@ -464,13 +435,7 @@ func (c *GitHubClient) GetUserIDs(usernames []string) ([]string, error) {
 			return nil, fmt.Errorf("failed to get user %s: %w", username, err)
 		}
 
-		var response struct {
-			Data struct {
-				User struct {
-					ID string `json:"id"`
-				} `json:"user"`
-			} `json:"data"`
-		}
+		var response UserQueryResponse
 
 		if err := json.Unmarshal(responseData, &response); err != nil {
 			return nil, err
@@ -510,18 +475,7 @@ func (c *GitHubClient) GetMilestoneID(title string) (string, error) {
 		return "", err
 	}
 
-	var response struct {
-		Data struct {
-			Repository struct {
-				Milestones struct {
-					Nodes []struct {
-						ID    string `json:"id"`
-						Title string `json:"title"`
-					} `json:"nodes"`
-				} `json:"milestones"`
-			} `json:"repository"`
-		} `json:"data"`
-	}
+	var response MilestoneQueryResponse
 
 	if err := json.Unmarshal(responseData, &response); err != nil {
 		return "", err
@@ -563,18 +517,7 @@ func (c *GitHubClient) GetProjectID(name string) (string, error) {
 		return "", err
 	}
 
-	var response struct {
-		Data struct {
-			Repository struct {
-				ProjectsV2 struct {
-					Nodes []struct {
-						ID    string `json:"id"`
-						Title string `json:"title"`
-					} `json:"nodes"`
-				} `json:"projectsV2"`
-			} `json:"repository"`
-		} `json:"data"`
-	}
+	var response ProjectQueryResponse
 
 	if err := json.Unmarshal(responseData, &response); err != nil {
 		return "", err
@@ -620,41 +563,7 @@ func (c *GitHubClient) GetIssueWithSubIssues(number int, includeSub bool, detail
 		return nil, fmt.Errorf("failed to fetch issue: %w", err)
 	}
 
-	var response struct {
-		Data struct {
-			Repository struct {
-				Issue *struct {
-					Number    int    `json:"number"`
-					Title     string `json:"title"`
-					State     string `json:"state"`
-					Body      string `json:"body"`
-					URL       string `json:"url"`
-					CreatedAt string `json:"createdAt"`
-					UpdatedAt string `json:"updatedAt"`
-					Labels    struct {
-						Nodes []struct {
-							Name string `json:"name"`
-						} `json:"nodes"`
-					} `json:"labels"`
-					Assignees struct {
-						Nodes []struct {
-							Login string `json:"login"`
-						} `json:"nodes"`
-					} `json:"assignees"`
-					SubIssues *struct {
-						TotalCount int `json:"totalCount"`
-						Nodes      []struct {
-							ID     string `json:"id"`
-							Number int    `json:"number"`
-							Title  string `json:"title"`
-							State  string `json:"state"`
-							Closed bool   `json:"closed"`
-						} `json:"nodes"`
-					} `json:"subIssues,omitempty"`
-				} `json:"issue"`
-			} `json:"repository"`
-		} `json:"data"`
-	}
+	var response IssueWithSubIssuesResponse
 
 	if err := json.Unmarshal(responseData, &response); err != nil {
 		return nil, fmt.Errorf("failed to parse response: %w", err)
@@ -761,18 +670,7 @@ func (c *GitHubClient) RemoveSubIssue(childNumber int) (*BasicIssueInfo, error) 
 		return nil, fmt.Errorf("failed to get child issue: %w", err)
 	}
 
-	var childResponse struct {
-		Data struct {
-			Repository struct {
-				Issue *struct {
-					ID    string `json:"id"`
-					Title string `json:"title"`
-					URL   string `json:"url"`
-					State string `json:"state"`
-				} `json:"issue"`
-			} `json:"repository"`
-		} `json:"data"`
-	}
+	var childResponse GetRepositoryIssueResponse
 
 	if err := json.Unmarshal(childData, &childResponse); err != nil {
 		return nil, err
@@ -806,16 +704,7 @@ func (c *GitHubClient) RemoveSubIssue(childNumber int) (*BasicIssueInfo, error) 
 		return nil, fmt.Errorf("failed to get parent issue: %w", err)
 	}
 
-	var parentResponse struct {
-		Data struct {
-			Node struct {
-				Parent *struct {
-					ID string `json:"id"`
-				} `json:"parent"`
-			} `json:"node"`
-		} `json:"data"`
-	}
-
+	var parentResponse NodeQueryParentResponse
 	if err := json.Unmarshal(parentData, &parentResponse); err != nil {
 		return nil, err
 	}
@@ -853,20 +742,7 @@ func (c *GitHubClient) RemoveSubIssue(childNumber int) (*BasicIssueInfo, error) 
 		return nil, fmt.Errorf("failed to remove sub-issue relationship: %w", err)
 	}
 
-	var response struct {
-		Data struct {
-			RemoveSubIssue struct {
-				Issue struct {
-					ID     string `json:"id"`
-					Number int    `json:"number"`
-					Title  string `json:"title"`
-					URL    string `json:"url"`
-					State  string `json:"state"`
-				} `json:"issue"`
-			} `json:"removeSubIssue"`
-		} `json:"data"`
-	}
-
+	var response RemoveSubIssueMutationResponse
 	if err := json.Unmarshal(responseData, &response); err != nil {
 		return nil, err
 	}
@@ -914,15 +790,7 @@ func (c *GitHubClient) SetIssueParent(childNumber int, parentNumber int, overwri
 		return nil, fmt.Errorf("failed to fetch issues: %w", err)
 	}
 
-	var response struct {
-		Data struct {
-			Repository struct {
-				Child  *issueNode `json:"child"`
-				Parent *issueNode `json:"parent"`
-			} `json:"repository"`
-		} `json:"data"`
-	}
-
+	var response GetRepositoryIssuesResponse
 	if err := json.Unmarshal(responseData, &response); err != nil {
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
@@ -973,15 +841,7 @@ func (c *GitHubClient) SetIssueParent(childNumber int, parentNumber int, overwri
 		return nil, fmt.Errorf("failed to set parent relationship: %w", err)
 	}
 
-	var linkResponse struct {
-		Data struct {
-			AddSubIssue struct {
-				Issue    issueNode `json:"issue"`
-				SubIssue issueNode `json:"subIssue"`
-			} `json:"addSubIssue"`
-		} `json:"data"`
-	}
-
+	var linkResponse AddSubIssueMutationResponse
 	if err := json.Unmarshal(linkResponseData, &linkResponse); err != nil {
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
@@ -1061,16 +921,7 @@ func (c *GitHubClient) AddSubIssue(childID string, parentNumber int) (*ParentIss
 		return nil, fmt.Errorf("failed to get parent issue: %w", err)
 	}
 
-	var parentResponse struct {
-		Data struct {
-			Repository struct {
-				Issue struct {
-					ID    string `json:"id"`
-					Title string `json:"title"`
-				} `json:"issue"`
-			} `json:"repository"`
-		} `json:"data"`
-	}
+	var parentResponse GetRepositoryIssueResponse
 
 	if err := json.Unmarshal(parentData, &parentResponse); err != nil {
 		return nil, err
@@ -1183,17 +1034,8 @@ type ParentChangeInfo struct {
 	Action    string          `json:"action"`
 }
 
-// issueNode represents the Issue node from GitHub GraphQL API responses
-type issueNode struct {
-	ID    string `json:"id"`
-	Number int    `json:"number"`
-	Title  string `json:"title"`
-	URL    string `json:"url"`
-	State  string `json:"state"`
-}
-
-// toBasicIssueInfo converts an issueNode to BasicIssueInfo
-func (n *issueNode) toBasicIssueInfo() BasicIssueInfo {
+// toBasicIssueInfo converts GitHub API IssueFields to our custom BasicIssueInfo type
+func (n *IssueFields) toBasicIssueInfo() BasicIssueInfo {
 	return BasicIssueInfo{
 		Number: n.Number,
 		Title:  n.Title,
@@ -1256,15 +1098,7 @@ func linkParent(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to fetch issues: %w", err)
 	}
 
-	var response struct {
-		Data struct {
-			Repository struct {
-				Child  *issueNode `json:"child"`
-				Parent *issueNode `json:"parent"`
-			} `json:"repository"`
-		} `json:"data"`
-	}
-
+	var response GetRepositoryIssuesResponse
 	if err := json.Unmarshal(responseData, &response); err != nil {
 		return fmt.Errorf("failed to parse response: %w", err)
 	}
@@ -1314,15 +1148,7 @@ func linkParent(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create sub-issue relationship: %w", err)
 	}
 
-	var linkResponse struct {
-		Data struct {
-			AddSubIssue struct {
-				Issue    issueNode `json:"issue"`
-				SubIssue issueNode `json:"subIssue"`
-			} `json:"addSubIssue"`
-		} `json:"data"`
-	}
-
+	var linkResponse AddSubIssueMutationResponse
 	if err := json.Unmarshal(linkResponseData, &linkResponse); err != nil {
 		return fmt.Errorf("failed to parse link-parent response: %w", err)
 	}
@@ -1419,23 +1245,7 @@ func (c *GitHubClient) ReorderSubIssue(subIssueNumber int, afterNumber int, befo
 		return nil, fmt.Errorf("failed to fetch issue: %w", err)
 	}
 
-	var response struct {
-		Data struct {
-			Repository struct {
-				Issue *struct {
-					ID    string `json:"id"`
-					Title string `json:"title"`
-					URL   string `json:"url"`
-					State string `json:"state"`
-					Parent *struct {
-						ID     string `json:"id"`
-						Number int    `json:"number"`
-						Title  string `json:"title"`
-					} `json:"parent"`
-				} `json:"issue"`
-			} `json:"repository"`
-		} `json:"data"`
-	}
+	var response IssueQueryResponse
 
 	if err := json.Unmarshal(responseData, &response); err != nil {
 		return nil, err
@@ -1465,15 +1275,7 @@ func (c *GitHubClient) ReorderSubIssue(subIssueNumber int, afterNumber int, befo
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch 'after' issue: %w", err)
 		}
-		var afterResp struct {
-			Data struct {
-				Repository struct {
-					Issue *struct {
-						ID string `json:"id"`
-					} `json:"issue"`
-				} `json:"repository"`
-			} `json:"data"`
-		}
+		var afterResp GetRepositoryIssueResponse
 		if err := json.Unmarshal(afterData, &afterResp); err != nil {
 			return nil, err
 		}
@@ -1495,15 +1297,7 @@ func (c *GitHubClient) ReorderSubIssue(subIssueNumber int, afterNumber int, befo
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch 'before' issue: %w", err)
 		}
-		var beforeResp struct {
-			Data struct {
-				Repository struct {
-					Issue *struct {
-						ID string `json:"id"`
-					} `json:"issue"`
-				} `json:"repository"`
-			} `json:"data"`
-		}
+		var beforeResp GetRepositoryIssueResponse
 		if err := json.Unmarshal(beforeData, &beforeResp); err != nil {
 			return nil, err
 		}
@@ -1554,17 +1348,7 @@ func (c *GitHubClient) ReorderSubIssue(subIssueNumber int, afterNumber int, befo
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch first sub-issue: %w", err)
 		}
-		var firstResp struct {
-			Data struct {
-				Node struct {
-					SubIssues struct {
-						Nodes []struct {
-							ID string `json:"id"`
-						} `json:"nodes"`
-					} `json:"subIssues"`
-				} `json:"node"`
-			} `json:"data"`
-		}
+		var firstResp NodeQuerySubIssuesResponse
 		if err := json.Unmarshal(firstData, &firstResp); err != nil {
 			return nil, err
 		}
@@ -1591,17 +1375,7 @@ func (c *GitHubClient) ReorderSubIssue(subIssueNumber int, afterNumber int, befo
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch last sub-issue: %w", err)
 		}
-		var lastResp struct {
-			Data struct {
-				Node struct {
-					SubIssues struct {
-						Nodes []struct {
-							ID string `json:"id"`
-						} `json:"nodes"`
-					} `json:"subIssues"`
-				} `json:"node"`
-			} `json:"data"`
-		}
+		var lastResp NodeQuerySubIssuesResponse
 		if err := json.Unmarshal(lastData, &lastResp); err != nil {
 			return nil, err
 		}
@@ -1626,17 +1400,7 @@ func (c *GitHubClient) ReorderSubIssue(subIssueNumber int, afterNumber int, befo
 		return nil, fmt.Errorf("failed to reorder sub-issue: %w", err)
 	}
 
-	var mutationResp struct {
-		Data struct {
-			ReprioritizeSubIssue struct {
-				Issue struct {
-					ID     string `json:"id"`
-					Number int    `json:"number"`
-					Title  string `json:"title"`
-				} `json:"issue"`
-			} `json:"reprioritizeSubIssue"`
-		} `json:"data"`
-	}
+	var mutationResp ReprioritizeSubIssueResponse
 
 	if err := json.Unmarshal(mutationData, &mutationResp); err != nil {
 		return nil, err
@@ -1695,18 +1459,7 @@ func (c *GitHubClient) BatchAddSubIssues(parentNumber int, subIssueNumbers []int
 		return nil, fmt.Errorf("failed to fetch parent issue: %w", err)
 	}
 
-	var parentResp struct {
-		Data struct {
-			Repository struct {
-				Issue *struct {
-					ID    string `json:"id"`
-					Title string `json:"title"`
-					URL   string `json:"url"`
-					State string `json:"state"`
-				} `json:"issue"`
-			} `json:"repository"`
-		} `json:"data"`
-	}
+	var parentResp GetRepositoryIssueResponse
 
 	if err := json.Unmarshal(parentData, &parentResp); err != nil {
 		return nil, err
@@ -1733,15 +1486,7 @@ func (c *GitHubClient) BatchAddSubIssues(parentNumber int, subIssueNumbers []int
 			return nil, fmt.Errorf("failed to fetch sub-issue #%d: %w", num, err)
 		}
 		
-		var subResp struct {
-			Data struct {
-				Repository struct {
-					Issue *struct {
-						ID string `json:"id"`
-					} `json:"issue"`
-				} `json:"repository"`
-			} `json:"data"`
-		}
+		var subResp GetRepositoryIssueResponse
 		
 		if err := json.Unmarshal(subData, &subResp); err != nil {
 			return nil, err
@@ -1826,18 +1571,7 @@ func (c *GitHubClient) BatchRemoveSubIssues(parentNumber int, subIssueNumbers []
 		return nil, fmt.Errorf("failed to fetch parent issue: %w", err)
 	}
 
-	var parentResp struct {
-		Data struct {
-			Repository struct {
-				Issue *struct {
-					ID    string `json:"id"`
-					Title string `json:"title"`
-					URL   string `json:"url"`
-					State string `json:"state"`
-				} `json:"issue"`
-			} `json:"repository"`
-		} `json:"data"`
-	}
+	var parentResp GetRepositoryIssueResponse
 
 	if err := json.Unmarshal(parentData, &parentResp); err != nil {
 		return nil, err
@@ -1864,15 +1598,7 @@ func (c *GitHubClient) BatchRemoveSubIssues(parentNumber int, subIssueNumbers []
 			return nil, fmt.Errorf("failed to fetch sub-issue #%d: %w", num, err)
 		}
 		
-		var subResp struct {
-			Data struct {
-				Repository struct {
-					Issue *struct {
-						ID string `json:"id"`
-					} `json:"issue"`
-				} `json:"repository"`
-			} `json:"data"`
-		}
+		var subResp GetRepositoryIssueResponse
 		
 		if err := json.Unmarshal(subData, &subResp); err != nil {
 			return nil, err

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 )
 
 require (
-	github.com/apstndb/github-schema-go v0.0.0-20250623021209-4b27beacd35d // indirect
+	github.com/apstndb/github-schema-go v0.0.0-20250623030722-1a817133ad59 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/itchyny/gojq v0.12.14 // indirect
 	github.com/itchyny/timefmt-go v0.1.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/apstndb/github-schema-go v0.0.0-20250622125526-5970e8d3bc99 h1:xKLHSw
 github.com/apstndb/github-schema-go v0.0.0-20250622125526-5970e8d3bc99/go.mod h1:xX8sF6fBexU4cW7qlwsiyCACd4astSm/hBDSBJWGAv4=
 github.com/apstndb/github-schema-go v0.0.0-20250623021209-4b27beacd35d h1:H50kN+FQB3/pk9dRLXFaXwDBQNBFFV0KXmR+VjVAYOg=
 github.com/apstndb/github-schema-go v0.0.0-20250623021209-4b27beacd35d/go.mod h1:4xU4lejA6zmr3FFKGHhw5fMOfTTtJ1LBe+mf6IkcYIY=
+github.com/apstndb/github-schema-go v0.0.0-20250623030722-1a817133ad59 h1:etEjIRy990CS5iXEG6D+jIR0/3UFHBA3nxEn3eN7eGU=
+github.com/apstndb/github-schema-go v0.0.0-20250623030722-1a817133ad59/go.mod h1:4xU4lejA6zmr3FFKGHhw5fMOfTTtJ1LBe+mf6IkcYIY=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
 github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=


### PR DESCRIPTION
## Summary
Implements comprehensive sub-issue management capabilities for the `issues edit` command as described in issue #36.

## Features Added

### Sub-issue Reordering
- `--after <issue-number>`: Place sub-issue after another sub-issue
- `--before <issue-number>`: Place sub-issue before another sub-issue  
- `--position first|last`: Move sub-issue to beginning or end of list

### Batch Operations
- `--add-subs <issue1,issue2,issue3>`: Add multiple sub-issues at once
- `--remove-subs <issue1,issue2,issue3>`: Remove multiple sub-issues at once

## Bug Fixes
- Fixed GraphQL field name: use `parent` instead of `parentIssue`
- Fixed `reprioritizeSubIssue` mutation field names (`issueId` instead of `parentIssueId`)
- Fixed response parsing for `ReprioritizeSubIssuePayload` (returns `issue` not `parentIssue`/`subIssue`)
- Fixed unused variable declarations in GraphQL queries

## Documentation
- Added guidance in CLAUDE.md about common GraphQL field naming mistakes
- Added instructions for verifying field names with `go tool github-schema`

## Testing
All functionality has been tested:
- ✅ Reordering sub-issues to first/last position
- ✅ Moving sub-issues after/before other sub-issues
- ✅ Batch adding multiple sub-issues
- ✅ Batch removing multiple sub-issues
- ✅ Unlinking parent relationships

## Technical Details
- Uses GraphQL mutations: `reprioritizeSubIssue`, `addSubIssue`, `removeSubIssue`
- Maintains backward compatibility with existing `--parent` functionality
- Implements batch operations using GraphQL aliases for efficiency

Closes #36

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>