### PR TITLE
feat: auto-submit review comments to prevent pending state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,9 @@ make build              # Build gh-helper tool
 # New enhanced review features
 ./bin/gh-helper reviews wait <PR> --async --detailed  # Get comprehensive PR status
 ./bin/gh-helper reviews wait <PR> --request-summary   # Request and wait for Gemini summary
-./bin/gh-helper threads reply <ID1> <ID2> <ID3> --resolve  # Bulk reply to threads
+./bin/gh-helper threads reply <ID1> <ID2> <ID3> --resolve  # Bulk reply to threads (auto-submits)
+./bin/gh-helper threads reply <ID> --no-submit        # Create pending comment (rare)
+./bin/gh-helper threads submit <PR>                   # Submit any pending comments
 
 # Schema introspection via github-schema-go tool for exploring GitHub's GraphQL API (see below)
 # github-schema-go provides type-safe access to GitHub's GraphQL schema for discovering available
@@ -112,12 +114,16 @@ git push origin HEAD  # Explicit push to current branch
 ### Review Thread Management
 - **Always resolve review threads** after addressing feedback
 - **CRITICAL:** Push commits BEFORE replying to threads - GitHub needs the commit to exist for proper linking
+- **Auto-submit by default**: Review comments are now automatically submitted (no longer pending)
 - **For threads requiring code changes**:
   1. Make the necessary changes and commit
   2. **Push the commit to GitHub first**: `git push origin HEAD`
   3. Reply with commit hash and resolve: `./bin/gh-helper threads reply <THREAD_ID> --commit-hash <HASH> --message "Fixed as suggested" --resolve`
 - **For threads not requiring changes**:
   1. Reply with explanation and resolve: `./bin/gh-helper threads reply <THREAD_ID> --message "Explanation here" --resolve`
+- **To create pending comments** (rare): Use `--no-submit` flag: `./bin/gh-helper threads reply <THREAD_ID> --message "Draft response" --no-submit`
+- **Submit pending comments**: `./bin/gh-helper threads submit <PR>` to publish all pending comments
+- **Detect pending comments**: `./bin/gh-helper reviews fetch <PR>` will warn about any pending comments
 - **Batch resolve multiple threads**: `./bin/gh-helper threads resolve <THREAD_ID1> <THREAD_ID2> <THREAD_ID3>`
 - **Bulk reply with custom messages**: `./bin/gh-helper threads reply THREAD1:"Fixed typo" THREAD2:"Refactored" --commit-hash <HASH> --resolve`
 

--- a/gh-helper/graphql_fragments.go
+++ b/gh-helper/graphql_fragments.go
@@ -70,6 +70,7 @@ type ThreadCommentFields struct {
 	} `json:"author"`
 	Body      string `json:"body"`
 	CreatedAt string `json:"createdAt"`
+	State     string `json:"state"`
 }
 
 // ThreadFields corresponds to fragment ThreadFields on PullRequestReviewThread

--- a/gh-helper/graphql_types.go
+++ b/gh-helper/graphql_types.go
@@ -125,6 +125,31 @@ type AddPullRequestReviewThreadReplyResponse struct {
 	} `json:"data"`
 }
 
+// Submit Pull Request Review Mutation
+type SubmitPullRequestReviewInput struct {
+	ClientMutationID    *string `json:"clientMutationId,omitempty"`
+	PullRequestID       *string `json:"pullRequestId,omitempty"`
+	PullRequestReviewID *string `json:"pullRequestReviewId,omitempty"`
+	Event               string  `json:"event"` // COMMENT, APPROVE, REQUEST_CHANGES, or DISMISS
+	Body                *string `json:"body,omitempty"`
+}
+
+type SubmitPullRequestReviewVariables struct {
+	Input SubmitPullRequestReviewInput `json:"input"`
+}
+
+type SubmitPullRequestReviewResponse struct {
+	Data struct {
+		SubmitPullRequestReview struct {
+			PullRequestReview struct {
+				ID    string `json:"id"`
+				State string `json:"state"`
+				Body  string `json:"body"`
+			} `json:"pullRequestReview"`
+		} `json:"submitPullRequestReview"`
+	} `json:"data"`
+}
+
 // Add Comment Mutation (for PR/Issue comments)
 type AddCommentInput struct {
 	ClientMutationID *string `json:"clientMutationId,omitempty"`

--- a/gh-helper/main.go
+++ b/gh-helper/main.go
@@ -1477,15 +1477,13 @@ func submitPendingComments(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid PR number: %w", err)
 	}
 	
-	// Query to get PR ID and any pending reviews
+	// Query to get any pending reviews (optimized to fetch only required fields)
 	// Using first: 100 to handle most cases without pagination
 	// For extremely rare cases with >100 pending reviews, pagination would be needed
 	query := `
 query($owner: String!, $repo: String!, $prNumber: Int!) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $prNumber) {
-      id
-      title
       reviews(first: 100, states: PENDING) {
         totalCount
         pageInfo {
@@ -1497,14 +1495,8 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
           author {
             login
           }
-          body
-          comments(first: 100) {
+          comments(first: 1) {
             totalCount
-            nodes {
-              id
-              state
-              body
-            }
           }
         }
       }
@@ -1530,8 +1522,6 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
 		Data struct {
 			Repository struct {
 				PullRequest struct {
-					ID      string `json:"id"`
-					Title   string `json:"title"`
 					Reviews struct {
 						TotalCount int `json:"totalCount"`
 						PageInfo struct {
@@ -1543,14 +1533,8 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
 							Author struct {
 								Login string `json:"login"`
 							} `json:"author"`
-							Body string `json:"body"`
 							Comments struct {
 								TotalCount int `json:"totalCount"`
-								Nodes []struct {
-									ID    string `json:"id"`
-									State string `json:"state"`
-									Body  string `json:"body"`
-								} `json:"nodes"`
 							} `json:"comments"`
 						} `json:"nodes"`
 					} `json:"reviews"`

--- a/gh-helper/main.go
+++ b/gh-helper/main.go
@@ -1602,13 +1602,9 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
 			continue
 		}
 		
-		// Count pending comments in this review
-		pendingCommentCount := 0
-		for _, comment := range review.Comments.Nodes {
-			if comment.State == "PENDING" {
-				pendingCommentCount++
-			}
-		}
+		// Since the review state is PENDING, all its comments are also pending.
+		// Using TotalCount is more accurate as it's not limited by pagination (first: 100).
+		pendingCommentCount := review.Comments.TotalCount
 		
 		// Submit the review
 		submitMutation := `

--- a/gh-helper/main.go
+++ b/gh-helper/main.go
@@ -1478,13 +1478,20 @@ func submitPendingComments(cmd *cobra.Command, args []string) error {
 	}
 	
 	// Query to get PR ID and any pending reviews
+	// Using first: 100 to handle most cases without pagination
+	// For extremely rare cases with >100 pending reviews, pagination would be needed
 	query := `
 query($owner: String!, $repo: String!, $prNumber: Int!) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $prNumber) {
       id
       title
-      reviews(last: 50, states: PENDING) {
+      reviews(first: 100, states: PENDING) {
+        totalCount
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
         nodes {
           id
           author {
@@ -1526,6 +1533,11 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
 					ID      string `json:"id"`
 					Title   string `json:"title"`
 					Reviews struct {
+						TotalCount int `json:"totalCount"`
+						PageInfo struct {
+							HasNextPage bool   `json:"hasNextPage"`
+							EndCursor   string `json:"endCursor"`
+						} `json:"pageInfo"`
 						Nodes []struct {
 							ID     string `json:"id"`
 							Author struct {
@@ -1556,7 +1568,14 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
 	
 	// prID := response.Data.Repository.PullRequest.ID // Not needed for current implementation
 	currentUser := response.Data.Viewer.Login
-	pendingReviews := response.Data.Repository.PullRequest.Reviews.Nodes
+	reviews := response.Data.Repository.PullRequest.Reviews
+	pendingReviews := reviews.Nodes
+	
+	// Warn if there are more pending reviews than we fetched
+	if reviews.PageInfo.HasNextPage {
+		WarningMsg("More than 100 pending reviews found (total: %d). Only processing first 100.", reviews.TotalCount).Print()
+		WarningMsg("Consider running this command multiple times or implementing full pagination.").Print()
+	}
 	
 	if len(pendingReviews) == 0 {
 		InfoMsg("No pending reviews found for PR #%s", prNumber).Print()
@@ -1835,7 +1854,7 @@ func executeReplyMutation(client *GitHubClient, threadID, body string, result *r
 	// Auto-submit is enabled by default (inverted from noSubmit flag)
 	autoSubmit := !noSubmit
 	
-	err := client.ReplyToThread(threadID, body, autoSubmit)
+	commentID, commentURL, err := client.ReplyToThread(threadID, body, autoSubmit)
 	if err != nil {
 		return err
 	}
@@ -1843,6 +1862,8 @@ func executeReplyMutation(client *GitHubClient, threadID, body string, result *r
 	// Set basic success info
 	result.Status = "success"
 	result.Message = body
+	result.CommentID = commentID
+	result.URL = commentURL
 	
 	// Note: With the improved implementation, comments are only pending if there was
 	// already a pending review. The ReplyToThread method handles this intelligently.

--- a/gh-helper/main.go
+++ b/gh-helper/main.go
@@ -1483,13 +1483,22 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $prNumber) {
       id
-      reviews(last: 10, states: PENDING) {
+      title
+      reviews(last: 50, states: PENDING) {
         nodes {
           id
           author {
             login
           }
-          bodyText
+          body
+          comments(first: 100) {
+            totalCount
+            nodes {
+              id
+              state
+              body
+            }
+          }
         }
       }
     }
@@ -1515,13 +1524,22 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
 			Repository struct {
 				PullRequest struct {
 					ID      string `json:"id"`
+					Title   string `json:"title"`
 					Reviews struct {
 						Nodes []struct {
 							ID     string `json:"id"`
 							Author struct {
 								Login string `json:"login"`
 							} `json:"author"`
-							BodyText string `json:"bodyText"`
+							Body string `json:"body"`
+							Comments struct {
+								TotalCount int `json:"totalCount"`
+								Nodes []struct {
+									ID    string `json:"id"`
+									State string `json:"state"`
+									Body  string `json:"body"`
+								} `json:"nodes"`
+							} `json:"comments"`
 						} `json:"nodes"`
 					} `json:"reviews"`
 				} `json:"pullRequest"`
@@ -1556,7 +1574,21 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
 		// Only submit reviews owned by the current user
 		if review.Author.Login != currentUser {
 			InfoMsg("Skipping pending review by %s (not owned by current user)", review.Author.Login).Print()
+			results = append(results, map[string]interface{}{
+				"reviewId": review.ID,
+				"author":   review.Author.Login,
+				"status":   "skipped",
+				"reason":   "not owned by current user",
+			})
 			continue
+		}
+		
+		// Count pending comments in this review
+		pendingCommentCount := 0
+		for _, comment := range review.Comments.Nodes {
+			if comment.State == "PENDING" {
+				pendingCommentCount++
+			}
 		}
 		
 		// Submit the review
@@ -1582,9 +1614,10 @@ mutation($reviewID: ID!) {
 		if err != nil {
 			WarningMsg("Failed to submit review %s: %v", review.ID, err).Print()
 			results = append(results, map[string]interface{}{
-				"reviewId": review.ID,
-				"status":   "failed",
-				"error":    err.Error(),
+				"reviewId":             review.ID,
+				"status":               "failed",
+				"error":                err.Error(),
+				"pendingCommentCount":  pendingCommentCount,
 			})
 			continue
 		}
@@ -1610,13 +1643,14 @@ mutation($reviewID: ID!) {
 		submittedCount++
 		
 		results = append(results, map[string]interface{}{
-			"reviewId":    submittedReview.ID,
-			"status":      "submitted",
-			"state":       submittedReview.State,
-			"submittedAt": submittedReview.SubmittedAt,
+			"reviewId":            submittedReview.ID,
+			"status":              "submitted",
+			"state":               submittedReview.State,
+			"submittedAt":         submittedReview.SubmittedAt,
+			"commentsPublished":   review.Comments.TotalCount,
 		})
 		
-		SuccessMsg("Submitted pending review %s", review.ID).Print()
+		SuccessMsg("Submitted pending review %s (%d comments published)", review.ID, review.Comments.TotalCount).Print()
 	}
 	
 	// Summary output
@@ -1797,7 +1831,7 @@ func hasCustomMessages(inputs []threadInput) bool {
 
 // Helper function to execute reply mutation
 func executeReplyMutation(client *GitHubClient, threadID, body string, result *replyResult) error {
-	// Use the ReplyToThread method which handles auto-submit
+	// Use the ReplyToThread method which handles intelligent auto-submit
 	// Auto-submit is enabled by default (inverted from noSubmit flag)
 	autoSubmit := !noSubmit
 	
@@ -1810,9 +1844,10 @@ func executeReplyMutation(client *GitHubClient, threadID, body string, result *r
 	result.Status = "success"
 	result.Message = body
 	
-	// Indicate whether the reply was auto-submitted or left pending
+	// Note: With the improved implementation, comments are only pending if there was
+	// already a pending review. The ReplyToThread method handles this intelligently.
 	if !autoSubmit {
-		InfoMsg("Comment created as pending (use --no-submit=false to auto-submit)").Print()
+		InfoMsg("Auto-submit disabled. Comment may be pending if added to an existing pending review.").Print()
 	}
 	
 	return nil

--- a/gh-helper/main.go
+++ b/gh-helper/main.go
@@ -214,6 +214,30 @@ Examples:
 	resolveThread,
 )
 
+var submitThreadsCmd = NewOperationalCommand(
+	"submit [pr-number]",
+	"Submit pending review comments",
+	`Submit all pending review comments for a pull request.
+
+This command submits any pending review comments that haven't been published yet.
+Pending comments are created when replying to threads with --no-submit flag or
+when using older tools that don't auto-submit reviews.
+
+` + prNumberArgsHelp + `
+
+Examples:
+  # Submit all pending comments for current branch's PR
+  gh-helper threads submit
+  
+  # Submit pending comments for specific PR
+  gh-helper threads submit 123
+  
+  # Check for pending comments first, then submit
+  gh-helper reviews fetch 123 --list-threads
+  gh-helper threads submit 123`,
+	submitPendingComments,
+)
+
 // replyWithCommitCmd removed - use 'threads reply' with --message for commit references
 
 var (
@@ -230,6 +254,7 @@ var (
 	async          bool
 	detailed       bool
 	requestSummary bool
+	noSubmit       bool
 )
 
 // Common help text for PR number arguments
@@ -269,6 +294,7 @@ func init() {
 	replyThreadsCmd.Flags().StringVar(&mentionUser, "mention", "", "Username to mention (without @)")
 	replyThreadsCmd.Flags().StringVar(&commitHash, "commit-hash", "", "Commit hash to reference in reply")
 	replyThreadsCmd.Flags().BoolVar(&autoResolve, "resolve", false, "Automatically resolve thread after replying")
+	replyThreadsCmd.Flags().BoolVar(&noSubmit, "no-submit", false, "Don't auto-submit review (creates pending comment)")
 	replyThreadsCmd.Flags().Bool("parallel", true, "Execute mutations concurrently")
 	replyThreadsCmd.Flags().Int("max-concurrent", 5, "Maximum concurrent requests")
 
@@ -284,7 +310,7 @@ func init() {
 
 	// Add subcommands
 	reviewsCmd.AddCommand(fetchReviewsCmd, waitReviewsCmd)
-	threadsCmd.AddCommand(showThreadCmd, replyThreadsCmd, resolveThreadCmd)
+	threadsCmd.AddCommand(showThreadCmd, replyThreadsCmd, resolveThreadCmd, submitThreadsCmd)
 	rootCmd.AddCommand(reviewsCmd, threadsCmd, labelsCmd, issuesCmd, releasesCmd, nodeIDCmd)
 }
 
@@ -1435,6 +1461,181 @@ func resolveThread(cmd *cobra.Command, args []string) error {
 	return EncodeOutputWithCmd(cmd, results)
 }
 
+func submitPendingComments(cmd *cobra.Command, args []string) error {
+	// Create GitHub client
+	client := NewGitHubClient(owner, repo)
+	
+	// Resolve PR number
+	prNumber, err := resolvePRNumberFromArgs(args, client)
+	if err != nil {
+		return err
+	}
+	
+	// Get PR ID for the submit mutation
+	prNumberInt, err := strconv.Atoi(prNumber)
+	if err != nil {
+		return fmt.Errorf("invalid PR number: %w", err)
+	}
+	
+	// Query to get PR ID and any pending reviews
+	query := `
+query($owner: String!, $repo: String!, $prNumber: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $prNumber) {
+      id
+      reviews(last: 10, states: PENDING) {
+        nodes {
+          id
+          author {
+            login
+          }
+          bodyText
+        }
+      }
+    }
+  }
+  viewer {
+    login
+  }
+}`
+
+	variables := map[string]interface{}{
+		"owner":    owner,
+		"repo":     repo,
+		"prNumber": prNumberInt,
+	}
+	
+	result, err := client.RunGraphQLQueryWithVariables(query, variables)
+	if err != nil {
+		return fmt.Errorf("failed to fetch PR data: %w", err)
+	}
+	
+	var response struct {
+		Data struct {
+			Repository struct {
+				PullRequest struct {
+					ID      string `json:"id"`
+					Reviews struct {
+						Nodes []struct {
+							ID     string `json:"id"`
+							Author struct {
+								Login string `json:"login"`
+							} `json:"author"`
+							BodyText string `json:"bodyText"`
+						} `json:"nodes"`
+					} `json:"reviews"`
+				} `json:"pullRequest"`
+			} `json:"repository"`
+			Viewer struct {
+				Login string `json:"login"`
+			} `json:"viewer"`
+		} `json:"data"`
+	}
+	
+	if err := Unmarshal(result, &response); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+	
+	// prID := response.Data.Repository.PullRequest.ID // Not needed for current implementation
+	currentUser := response.Data.Viewer.Login
+	pendingReviews := response.Data.Repository.PullRequest.Reviews.Nodes
+	
+	if len(pendingReviews) == 0 {
+		InfoMsg("No pending reviews found for PR #%s", prNumber).Print()
+		return EncodeOutputWithCmd(cmd, map[string]interface{}{
+			"message": "No pending reviews to submit",
+			"prNumber": prNumber,
+		})
+	}
+	
+	// Submit each pending review owned by the current user
+	submittedCount := 0
+	results := []map[string]interface{}{}
+	
+	for _, review := range pendingReviews {
+		// Only submit reviews owned by the current user
+		if review.Author.Login != currentUser {
+			InfoMsg("Skipping pending review by %s (not owned by current user)", review.Author.Login).Print()
+			continue
+		}
+		
+		// Submit the review
+		submitMutation := `
+mutation($reviewID: ID!) {
+  submitPullRequestReview(input: {
+    pullRequestReviewId: $reviewID
+    event: COMMENT
+  }) {
+    pullRequestReview {
+      id
+      state
+      submittedAt
+    }
+  }
+}`
+		
+		submitVars := map[string]interface{}{
+			"reviewID": review.ID,
+		}
+		
+		submitResult, err := client.RunGraphQLQueryWithVariables(submitMutation, submitVars)
+		if err != nil {
+			WarningMsg("Failed to submit review %s: %v", review.ID, err).Print()
+			results = append(results, map[string]interface{}{
+				"reviewId": review.ID,
+				"status":   "failed",
+				"error":    err.Error(),
+			})
+			continue
+		}
+		
+		var submitResponse struct {
+			Data struct {
+				SubmitPullRequestReview struct {
+					PullRequestReview struct {
+						ID          string `json:"id"`
+						State       string `json:"state"`
+						SubmittedAt string `json:"submittedAt"`
+					} `json:"pullRequestReview"`
+				} `json:"submitPullRequestReview"`
+			} `json:"data"`
+		}
+		
+		if err := Unmarshal(submitResult, &submitResponse); err != nil {
+			WarningMsg("Failed to parse submit response: %v", err).Print()
+			continue
+		}
+		
+		submittedReview := submitResponse.Data.SubmitPullRequestReview.PullRequestReview
+		submittedCount++
+		
+		results = append(results, map[string]interface{}{
+			"reviewId":    submittedReview.ID,
+			"status":      "submitted",
+			"state":       submittedReview.State,
+			"submittedAt": submittedReview.SubmittedAt,
+		})
+		
+		SuccessMsg("Submitted pending review %s", review.ID).Print()
+	}
+	
+	// Summary output
+	output := map[string]interface{}{
+		"prNumber":           prNumber,
+		"pendingReviewsFound": len(pendingReviews),
+		"reviewsSubmitted":   submittedCount,
+		"results":            results,
+	}
+	
+	if submittedCount > 0 {
+		output["message"] = fmt.Sprintf("Successfully submitted %d pending review(s)", submittedCount)
+	} else {
+		output["message"] = "No reviews were submitted (none owned by current user)"
+	}
+	
+	return EncodeOutputWithCmd(cmd, output)
+}
+
 // threadInput represents a thread ID with optional custom message
 type threadInput struct {
 	ID            string
@@ -1596,53 +1797,23 @@ func hasCustomMessages(inputs []threadInput) bool {
 
 // Helper function to execute reply mutation
 func executeReplyMutation(client *GitHubClient, threadID, body string, result *replyResult) error {
-	mutation := `
-mutation($threadID: ID!, $body: String!) {
-  addPullRequestReviewThreadReply(input: {
-    pullRequestReviewThreadId: $threadID
-    body: $body
-  }) {
-    comment {
-      id
-      url
-      body
-    }
-  }
-}`
-
-	variables := map[string]interface{}{
-		"threadID": threadID,
-		"body":     body,
-	}
-
-	responseData, err := client.RunGraphQLQueryWithVariables(mutation, variables)
+	// Use the ReplyToThread method which handles auto-submit
+	// Auto-submit is enabled by default (inverted from noSubmit flag)
+	autoSubmit := !noSubmit
+	
+	err := client.ReplyToThread(threadID, body, autoSubmit)
 	if err != nil {
 		return err
 	}
 
-	var response struct {
-		Data struct {
-			AddPullRequestReviewThreadReply struct {
-				Comment struct {
-					ID  string `json:"id"`
-					URL string `json:"url"`
-					Body string `json:"body"`
-				} `json:"comment"`
-			} `json:"addPullRequestReviewThreadReply"`
-		} `json:"data"`
+	// Set basic success info
+	result.Status = "success"
+	result.Message = body
+	
+	// Indicate whether the reply was auto-submitted or left pending
+	if !autoSubmit {
+		InfoMsg("Comment created as pending (use --no-submit=false to auto-submit)").Print()
 	}
-
-	if err := Unmarshal(responseData, &response); err != nil {
-		return fmt.Errorf("failed to parse response: %w", err)
-	}
-
-	comment := response.Data.AddPullRequestReviewThreadReply.Comment
-	if comment.ID == "" {
-		return fmt.Errorf("reply posting failed: empty response")
-	}
-
-	result.CommentID = comment.ID
-	result.URL = comment.URL
 	
 	return nil
 }

--- a/gh-helper/main.go
+++ b/gh-helper/main.go
@@ -1569,6 +1569,34 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
 		})
 	}
 	
+	// Define the mutation outside the loop for better performance
+	submitMutation := `
+mutation($reviewID: ID!) {
+  submitPullRequestReview(input: {
+    pullRequestReviewId: $reviewID
+    event: COMMENT
+  }) {
+    pullRequestReview {
+      id
+      state
+      submittedAt
+    }
+  }
+}`
+
+	// Define the response struct outside the loop for better performance
+	type submitResponseType struct {
+		Data struct {
+			SubmitPullRequestReview struct {
+				PullRequestReview struct {
+					ID          string `json:"id"`
+					State       string `json:"state"`
+					SubmittedAt string `json:"submittedAt"`
+				} `json:"pullRequestReview"`
+			} `json:"submitPullRequestReview"`
+		} `json:"data"`
+	}
+
 	// Submit each pending review owned by the current user
 	submittedCount := 0
 	results := []map[string]interface{}{}
@@ -1591,20 +1619,6 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
 		pendingCommentCount := review.Comments.TotalCount
 		
 		// Submit the review
-		submitMutation := `
-mutation($reviewID: ID!) {
-  submitPullRequestReview(input: {
-    pullRequestReviewId: $reviewID
-    event: COMMENT
-  }) {
-    pullRequestReview {
-      id
-      state
-      submittedAt
-    }
-  }
-}`
-		
 		submitVars := map[string]interface{}{
 			"reviewID": review.ID,
 		}
@@ -1621,17 +1635,7 @@ mutation($reviewID: ID!) {
 			continue
 		}
 		
-		var submitResponse struct {
-			Data struct {
-				SubmitPullRequestReview struct {
-					PullRequestReview struct {
-						ID          string `json:"id"`
-						State       string `json:"state"`
-						SubmittedAt string `json:"submittedAt"`
-					} `json:"pullRequestReview"`
-				} `json:"submitPullRequestReview"`
-			} `json:"data"`
-		}
+		var submitResponse submitResponseType
 		
 		if err := Unmarshal(submitResult, &submitResponse); err != nil {
 			WarningMsg("Failed to parse submit response: %v", err).Print()

--- a/gh-helper/reviews_unified.go
+++ b/gh-helper/reviews_unified.go
@@ -295,7 +295,7 @@ func outputFetch(cmd *cobra.Command, data *UnifiedReviewData, includeReviewBodie
 		// Add pending comments warning if any are found
 		if pendingCommentsCount > 0 {
 			threadsOutput["pendingCommentsCount"] = pendingCommentsCount
-			threadsOutput["pendingWarning"] = fmt.Sprintf("⚠️ Found %d pending comment(s). Comments will be visible after review submission.", pendingCommentsCount)
+			threadsOutput["pendingWarning"] = fmt.Sprintf("⚠️ Found %d pending comment(s). Use 'threads submit' to publish them.", pendingCommentsCount)
 			
 			// Print warning to stderr so it's visible even with JSON/YAML output
 			WarningMsg("Found %d pending comment(s) in review threads. Use 'threads submit' to publish them.", pendingCommentsCount).Print()

--- a/gh-helper/reviews_unified.go
+++ b/gh-helper/reviews_unified.go
@@ -217,6 +217,7 @@ func outputFetch(cmd *cobra.Command, data *UnifiedReviewData, includeReviewBodie
 	// Threads section using GitHub GraphQL ReviewThread structure
 	if includeThreads {
 		unresolvedCount := 0
+		pendingCommentsCount := 0
 		unresolvedThreads := []map[string]interface{}{}
 		
 		// Filter for unresolved threads to display in the output
@@ -245,12 +246,22 @@ func outputFetch(cmd *cobra.Command, data *UnifiedReviewData, includeReviewBodie
 					
 					// Include all comments with author information
 					comments := []map[string]interface{}{}
+					hasPending := false
 					for _, comment := range thread.Comments {
 						commentData := map[string]interface{}{
 							"id":        comment.ID,
 							"author":    comment.Author,
 							"createdAt": comment.CreatedAt,
 							"body":      comment.Body,
+						}
+						
+						// Include state if present (PENDING or SUBMITTED)
+						if comment.State != "" {
+							commentData["state"] = comment.State
+							if comment.State == "PENDING" {
+								hasPending = true
+								pendingCommentsCount++
+							}
 						}
 						
 						// Include URL only if not empty (respects @skip directive)
@@ -261,6 +272,11 @@ func outputFetch(cmd *cobra.Command, data *UnifiedReviewData, includeReviewBodie
 						comments = append(comments, commentData)
 					}
 					threadData["comments"] = comments
+					
+					// Mark thread if it has pending comments
+					if hasPending {
+						threadData["hasPendingComments"] = true
+					}
 				}
 				
 				unresolvedThreads = append(unresolvedThreads, threadData)
@@ -270,11 +286,22 @@ func outputFetch(cmd *cobra.Command, data *UnifiedReviewData, includeReviewBodie
 		// Calculate total count from page info for accuracy
 		totalCount := data.ThreadPageInfo.TotalCount
 		
-		output["reviewThreads"] = map[string]interface{}{
+		threadsOutput := map[string]interface{}{
 			"totalCount":       totalCount,
 			"unresolvedCount":  unresolvedCount,
 			"unresolvedThreads": unresolvedThreads, // Unresolved threads
 		}
+		
+		// Add pending comments warning if any are found
+		if pendingCommentsCount > 0 {
+			threadsOutput["pendingCommentsCount"] = pendingCommentsCount
+			threadsOutput["pendingWarning"] = fmt.Sprintf("⚠️ Found %d pending comment(s). Comments will be visible after review submission.", pendingCommentsCount)
+			
+			// Print warning to stderr so it's visible even with JSON/YAML output
+			WarningMsg("Found %d pending comment(s) in review threads. Use 'threads submit' to publish them.", pendingCommentsCount).Print()
+		}
+		
+		output["reviewThreads"] = threadsOutput
 	}
 	
 	// Output using unified encoder

--- a/gh-helper/threads.go
+++ b/gh-helper/threads.go
@@ -24,6 +24,7 @@ type CommentInfo struct {
 	Body      string `json:"body"`
 	Author    string `json:"author"`
 	CreatedAt string `json:"createdAt"`
+	State     string `json:"state,omitempty"` // PENDING or SUBMITTED
 	DiffHunk  string `json:"diffHunk,omitempty"`
 }
 
@@ -118,6 +119,7 @@ query($owner: String!, $repo: String!, $prNumber: Int!, $limit: Int!, $excludeUr
 										Login string `json:"login"`
 									} `json:"author"`
 									CreatedAt string `json:"createdAt"`
+									State     string `json:"state"`
 									DiffHunk  string `json:"diffHunk"`
 								} `json:"nodes"`
 							} `json:"comments"`
@@ -152,6 +154,7 @@ query($owner: String!, $repo: String!, $prNumber: Int!, $limit: Int!, $excludeUr
 				Body:      comment.Body,
 				Author:    comment.Author.Login,
 				CreatedAt: comment.CreatedAt,
+				State:     comment.State,
 				DiffHunk:  comment.DiffHunk,
 			})
 		}
@@ -264,6 +267,7 @@ query($ids: [ID!]!, $excludeUrls: Boolean!) {
 							Login string `json:"login"`
 						} `json:"author"`
 						CreatedAt string `json:"createdAt"`
+						State     string `json:"state"`
 						DiffHunk  string `json:"diffHunk"`
 					} `json:"nodes"`
 				} `json:"comments"`
@@ -290,6 +294,7 @@ query($ids: [ID!]!, $excludeUrls: Boolean!) {
 				Body:      comment.Body,
 				Author:    comment.Author.Login,
 				CreatedAt: comment.CreatedAt,
+				State:     comment.State,
 				DiffHunk:  comment.DiffHunk,
 			})
 		}
@@ -314,10 +319,11 @@ query($ids: [ID!]!, $excludeUrls: Boolean!) {
 	return threads, nil
 }
 
-// ReplyToThread adds a reply to a review thread using GraphQL mutation
-// Uses addPullRequestReviewThreadReply to avoid creating pending reviews
-func (c *GitHubClient) ReplyToThread(threadID, body string) error {
-	mutation := `
+// ReplyToThread adds a reply to a review thread and automatically submits it
+// Uses addPullRequestReviewThreadReply followed by submitPullRequestReview to avoid pending comments
+func (c *GitHubClient) ReplyToThread(threadID, body string, autoSubmit bool) error {
+	// First, add the reply to the thread (this creates a pending review)
+	replyMutation := `
 mutation($threadID: ID!, $body: String!) {
   addPullRequestReviewThreadReply(input: {
     pullRequestReviewThreadId: $threadID
@@ -326,6 +332,12 @@ mutation($threadID: ID!, $body: String!) {
     comment {
       id
       url
+      pullRequestReview {
+        id
+        pullRequest {
+          id
+        }
+      }
     }
   }
 }`
@@ -335,9 +347,84 @@ mutation($threadID: ID!, $body: String!) {
 		"body":     body,
 	}
 
-	_, err := c.RunGraphQLQueryWithVariables(mutation, variables)
+	result, err := c.RunGraphQLQueryWithVariables(replyMutation, variables)
 	if err != nil {
 		return fmt.Errorf("failed to reply to thread: %w", err)
+	}
+
+	// Parse the response to get review ID and PR ID for submit
+	var replyResponse struct {
+		Data struct {
+			AddPullRequestReviewThreadReply struct {
+				Comment struct {
+					ID                string `json:"id"`
+					URL               string `json:"url"`
+					PullRequestReview struct {
+						ID string `json:"id"`
+						PullRequest struct {
+							ID string `json:"id"`
+						} `json:"pullRequest"`
+					} `json:"pullRequestReview"`
+				} `json:"comment"`
+			} `json:"addPullRequestReviewThreadReply"`
+		} `json:"data"`
+	}
+
+	if err := Unmarshal(result, &replyResponse); err != nil {
+		return fmt.Errorf("failed to parse reply response: %w", err)
+	}
+
+	// Auto-submit the review if enabled (default behavior)
+	if autoSubmit {
+		reviewID := replyResponse.Data.AddPullRequestReviewThreadReply.Comment.PullRequestReview.ID
+		prID := replyResponse.Data.AddPullRequestReviewThreadReply.Comment.PullRequestReview.PullRequest.ID
+		
+		if reviewID != "" {
+			// Submit the pending review as COMMENT (no approval/rejection, just publish the comment)
+			submitMutation := `
+mutation($reviewID: ID!, $event: PullRequestReviewEvent!) {
+  submitPullRequestReview(input: {
+    pullRequestReviewId: $reviewID
+    event: $event
+  }) {
+    pullRequestReview {
+      id
+      state
+    }
+  }
+}`
+
+			submitVars := map[string]interface{}{
+				"reviewID": reviewID,
+				"event":    "COMMENT",
+			}
+
+			_, err := c.RunGraphQLQueryWithVariables(submitMutation, submitVars)
+			if err != nil {
+				// If we can't submit the review, try with PR ID instead
+				submitWithPRMutation := `
+mutation($prID: ID!, $event: PullRequestReviewEvent!) {
+  submitPullRequestReview(input: {
+    pullRequestId: $prID
+    event: $event
+  }) {
+    pullRequestReview {
+      id
+      state
+    }
+  }
+}`
+				submitWithPRVars := map[string]interface{}{
+					"prID":  prID,
+					"event": "COMMENT",
+				}
+				
+				_, err2 := c.RunGraphQLQueryWithVariables(submitWithPRMutation, submitWithPRVars)
+				if err2 != nil {
+					return fmt.Errorf("failed to auto-submit review (tried both review ID and PR ID): review error: %w, PR error: %w", err, err2)
+				}
+			}
+		}
 	}
 
 	return nil

--- a/gh-helper/threads.go
+++ b/gh-helper/threads.go
@@ -438,15 +438,13 @@ mutation($prID: ID!, $event: PullRequestReviewEvent!) {
 				
 				_, err2 := c.RunGraphQLQueryWithVariables(submitWithPRMutation, submitWithPRVars)
 				if err2 != nil {
-					// Both submission attempts failed
-					// This might be okay if the review was already submitted
-					// Check if it's actually an error or just already submitted
-					if comment.State == "PENDING" {
-						// Still pending after submission attempts - this is a real error
-						return "", "", fmt.Errorf("comment remains pending after submission attempts: review error: %w, PR error: %w", submitErr, err2)
-					}
-					// Comment is not pending, so submission errors can be ignored
+					// Both submission attempts failed. It's safer to return an error
+					// and let the user know, rather than potentially swallowing a real issue.
+					return "", "", fmt.Errorf("failed to submit review, and fallback submission also failed: original error: %w, fallback error: %w", submitErr, err2)
 				}
+			} else {
+				// No prID available for fallback, so we must return the original error.
+				return "", "", fmt.Errorf("failed to submit review and could not attempt fallback submission: %w", submitErr)
 			}
 		}
 	}

--- a/gh-helper/threads.go
+++ b/gh-helper/threads.go
@@ -319,10 +319,13 @@ query($ids: [ID!]!, $excludeUrls: Boolean!) {
 	return threads, nil
 }
 
-// ReplyToThread adds a reply to a review thread and automatically submits it
-// Uses addPullRequestReviewThreadReply followed by submitPullRequestReview to avoid pending comments
+// ReplyToThread adds a reply to a review thread and intelligently handles review submission
+// The mutation will either:
+// 1. Create a new review and auto-submit it (if no pending review exists)
+// 2. Add to an existing pending review (requires manual submission later)
 func (c *GitHubClient) ReplyToThread(threadID, body string, autoSubmit bool) error {
-	// First, add the reply to the thread (this creates a pending review)
+	// First, add the reply to the thread
+	// This will either create a new review or add to an existing pending review
 	replyMutation := `
 mutation($threadID: ID!, $body: String!) {
   addPullRequestReviewThreadReply(input: {
@@ -332,8 +335,10 @@ mutation($threadID: ID!, $body: String!) {
     comment {
       id
       url
+      state
       pullRequestReview {
         id
+        state
         pullRequest {
           id
         }
@@ -352,15 +357,17 @@ mutation($threadID: ID!, $body: String!) {
 		return fmt.Errorf("failed to reply to thread: %w", err)
 	}
 
-	// Parse the response to get review ID and PR ID for submit
+	// Parse the response to check if the comment is pending
 	var replyResponse struct {
 		Data struct {
 			AddPullRequestReviewThreadReply struct {
 				Comment struct {
 					ID                string `json:"id"`
 					URL               string `json:"url"`
+					State             string `json:"state"` // PENDING or SUBMITTED
 					PullRequestReview struct {
-						ID string `json:"id"`
+						ID    string `json:"id"`
+						State string `json:"state"` // PENDING, COMMENTED, etc.
 						PullRequest struct {
 							ID string `json:"id"`
 						} `json:"pullRequest"`
@@ -374,14 +381,16 @@ mutation($threadID: ID!, $body: String!) {
 		return fmt.Errorf("failed to parse reply response: %w", err)
 	}
 
-	// Auto-submit the review if enabled (default behavior)
-	if autoSubmit {
-		reviewID := replyResponse.Data.AddPullRequestReviewThreadReply.Comment.PullRequestReview.ID
-		prID := replyResponse.Data.AddPullRequestReviewThreadReply.Comment.PullRequestReview.PullRequest.ID
-		
-		if reviewID != "" {
-			// Submit the pending review as COMMENT (no approval/rejection, just publish the comment)
-			submitMutation := `
+	comment := replyResponse.Data.AddPullRequestReviewThreadReply.Comment
+	review := comment.PullRequestReview
+	
+	// Only attempt to submit if:
+	// 1. autoSubmit is enabled (default true)
+	// 2. The comment is PENDING (meaning it's part of a pending review)
+	// 3. We have a valid review ID
+	if autoSubmit && comment.State == "PENDING" && review.ID != "" {
+		// The comment is pending, so we need to submit the review
+		submitMutation := `
 mutation($reviewID: ID!, $event: PullRequestReviewEvent!) {
   submitPullRequestReview(input: {
     pullRequestReviewId: $reviewID
@@ -394,14 +403,17 @@ mutation($reviewID: ID!, $event: PullRequestReviewEvent!) {
   }
 }`
 
-			submitVars := map[string]interface{}{
-				"reviewID": reviewID,
-				"event":    "COMMENT",
-			}
+		submitVars := map[string]interface{}{
+			"reviewID": review.ID,
+			"event":    "COMMENT",
+		}
 
-			_, err := c.RunGraphQLQueryWithVariables(submitMutation, submitVars)
-			if err != nil {
-				// If we can't submit the review, try with PR ID instead
+		_, submitErr := c.RunGraphQLQueryWithVariables(submitMutation, submitVars)
+		if submitErr != nil {
+			// If we can't submit by review ID (e.g., it's already submitted), 
+			// try submitting any pending review on the PR
+			prID := review.PullRequest.ID
+			if prID != "" {
 				submitWithPRMutation := `
 mutation($prID: ID!, $event: PullRequestReviewEvent!) {
   submitPullRequestReview(input: {
@@ -421,7 +433,14 @@ mutation($prID: ID!, $event: PullRequestReviewEvent!) {
 				
 				_, err2 := c.RunGraphQLQueryWithVariables(submitWithPRMutation, submitWithPRVars)
 				if err2 != nil {
-					return fmt.Errorf("failed to auto-submit review (tried both review ID and PR ID): review error: %w, PR error: %w", err, err2)
+					// Both submission attempts failed
+					// This might be okay if the review was already submitted
+					// Check if it's actually an error or just already submitted
+					if comment.State == "PENDING" {
+						// Still pending after submission attempts - this is a real error
+						return fmt.Errorf("comment remains pending after submission attempts: review error: %w, PR error: %w", submitErr, err2)
+					}
+					// Comment is not pending, so submission errors can be ignored
 				}
 			}
 		}

--- a/gh-helper/threads.go
+++ b/gh-helper/threads.go
@@ -73,6 +73,7 @@ query($owner: String!, $repo: String!, $prNumber: Int!, $limit: Int!, $excludeUr
                 login
               }
               createdAt
+              state
               diffHunk
             }
           }
@@ -229,6 +230,7 @@ query($ids: [ID!]!, $excludeUrls: Boolean!) {
             login
           }
           createdAt
+          state
           diffHunk
         }
       }

--- a/gh-helper/threads.go
+++ b/gh-helper/threads.go
@@ -415,37 +415,39 @@ mutation($reviewID: ID!, $event: PullRequestReviewEvent!) {
 
 		_, submitErr := c.RunGraphQLQueryWithVariables(submitMutation, submitVars)
 		if submitErr != nil {
-			// If we can't submit by review ID (e.g., it's already submitted), 
-			// try submitting any pending review on the PR
-			prID := review.PullRequest.ID
-			if prID != "" {
-				submitWithPRMutation := `
-mutation($prID: ID!, $event: PullRequestReviewEvent!) {
-  submitPullRequestReview(input: {
-    pullRequestId: $prID
-    event: $event
-  }) {
-    pullRequestReview {
-      id
-      state
-    }
-  }
-}`
-				submitWithPRVars := map[string]interface{}{
-					"prID":  prID,
-					"event": "COMMENT",
-				}
-				
-				_, err2 := c.RunGraphQLQueryWithVariables(submitWithPRMutation, submitWithPRVars)
-				if err2 != nil {
-					// Both submission attempts failed. It's safer to return an error
-					// and let the user know, rather than potentially swallowing a real issue.
-					return "", "", fmt.Errorf("failed to submit review, and fallback submission also failed: original error: %w, fallback error: %w", submitErr, err2)
-				}
-			} else {
-				// No prID available for fallback, so we must return the original error.
-				return "", "", fmt.Errorf("failed to submit review and could not attempt fallback submission: %w", submitErr)
+			// The submission with a specific review ID failed. This can happen in a race condition
+			// if a concurrent reply already submitted the review. To handle this gracefully,
+			// we re-fetch the comment's state to see if it's now SUBMITTED.
+			checkStateQuery := `query($commentID: ID!) { node(id: $commentID) { ... on PullRequestReviewComment { state } } }`
+			checkStateVars := map[string]interface{}{"commentID": commentID}
+			
+			stateResult, stateErr := c.RunGraphQLQueryWithVariables(checkStateQuery, checkStateVars)
+			if stateErr != nil {
+				// We failed to submit and also failed to check the current state.
+				// It's safest to report both errors to the user.
+				return "", "", fmt.Errorf("failed to submit review, and state re-check also failed: original error: %w, check error: %w", submitErr, stateErr)
 			}
+			
+			var stateResponse struct {
+				Data struct {
+					Node struct {
+						State string `json:"state"`
+					} `json:"node"`
+				} `json:"data"`
+			}
+			if err := Unmarshal(stateResult, &stateResponse); err != nil {
+				// The state check query returned something unexpected.
+				return "", "", fmt.Errorf("failed to parse comment state check response: %w", err)
+			}
+			
+			if stateResponse.Data.Node.State == "SUBMITTED" {
+				// The comment is now submitted. This confirms a concurrent operation succeeded.
+				// We can treat this as a success for the current operation as well.
+				return commentID, commentURL, nil
+			}
+			
+			// If the comment is still PENDING, the original submission error is a real issue.
+			return "", "", fmt.Errorf("failed to submit review, and comment is still pending: %w", submitErr)
 		}
 	}
 

--- a/gh-helper/threads.go
+++ b/gh-helper/threads.go
@@ -323,7 +323,8 @@ query($ids: [ID!]!, $excludeUrls: Boolean!) {
 // The mutation will either:
 // 1. Create a new review and auto-submit it (if no pending review exists)
 // 2. Add to an existing pending review (requires manual submission later)
-func (c *GitHubClient) ReplyToThread(threadID, body string, autoSubmit bool) error {
+// Returns the comment ID and URL of the created comment
+func (c *GitHubClient) ReplyToThread(threadID, body string, autoSubmit bool) (string, string, error) {
 	// First, add the reply to the thread
 	// This will either create a new review or add to an existing pending review
 	replyMutation := `
@@ -354,7 +355,7 @@ mutation($threadID: ID!, $body: String!) {
 
 	result, err := c.RunGraphQLQueryWithVariables(replyMutation, variables)
 	if err != nil {
-		return fmt.Errorf("failed to reply to thread: %w", err)
+		return "", "", fmt.Errorf("failed to reply to thread: %w", err)
 	}
 
 	// Parse the response to check if the comment is pending
@@ -378,11 +379,15 @@ mutation($threadID: ID!, $body: String!) {
 	}
 
 	if err := Unmarshal(result, &replyResponse); err != nil {
-		return fmt.Errorf("failed to parse reply response: %w", err)
+		return "", "", fmt.Errorf("failed to parse reply response: %w", err)
 	}
 
 	comment := replyResponse.Data.AddPullRequestReviewThreadReply.Comment
 	review := comment.PullRequestReview
+	
+	// Store comment ID and URL to return
+	commentID := comment.ID
+	commentURL := comment.URL
 	
 	// Only attempt to submit if:
 	// 1. autoSubmit is enabled (default true)
@@ -438,7 +443,7 @@ mutation($prID: ID!, $event: PullRequestReviewEvent!) {
 					// Check if it's actually an error or just already submitted
 					if comment.State == "PENDING" {
 						// Still pending after submission attempts - this is a real error
-						return fmt.Errorf("comment remains pending after submission attempts: review error: %w, PR error: %w", submitErr, err2)
+						return "", "", fmt.Errorf("comment remains pending after submission attempts: review error: %w, PR error: %w", submitErr, err2)
 					}
 					// Comment is not pending, so submission errors can be ignored
 				}
@@ -446,7 +451,7 @@ mutation($prID: ID!, $event: PullRequestReviewEvent!) {
 		}
 	}
 
-	return nil
+	return commentID, commentURL, nil
 }
 
 // ResolveThread resolves a review thread using GraphQL mutation

--- a/gh-helper/unified_graphql.go
+++ b/gh-helper/unified_graphql.go
@@ -159,6 +159,7 @@ fragment ThreadCommentFields on PullRequestReviewComment {
   body
   author { login }
   createdAt
+  state
   diffHunk @include(if: $includeCommentDetails)
 }
 

--- a/gh-helper/unified_review.go
+++ b/gh-helper/unified_review.go
@@ -77,6 +77,7 @@ type ThreadComment struct {
 	Author    string `json:"author"`
 	Body      string `json:"body"`
 	CreatedAt string `json:"createdAt"`
+	State     string `json:"state,omitempty"` // PENDING or SUBMITTED
 }
 
 // UnifiedReviewOptions controls what data to fetch

--- a/gh-helper/unified_review.go
+++ b/gh-helper/unified_review.go
@@ -254,6 +254,7 @@ query($owner: String!, $repo: String!, $prNumber: Int!,
               author { login }
               body
               createdAt
+              state
             }
           }
         }
@@ -281,6 +282,7 @@ query($owner: String!, $repo: String!, $prNumber: Int!,
               author { login }
               body
               createdAt
+              state
             }
           }
         }
@@ -409,6 +411,7 @@ query($owner: String!, $repo: String!, $prNumber: Int!,
 									} `json:"author"`
 									Body      string `json:"body"`
 									CreatedAt string `json:"createdAt"`
+									State     string `json:"state"`
 								} `json:"nodes"`
 							} `json:"comments"`
 						} `json:"nodes"`
@@ -431,6 +434,7 @@ query($owner: String!, $repo: String!, $prNumber: Int!,
 									} `json:"author"`
 									Body      string `json:"body"`
 									CreatedAt string `json:"createdAt"`
+									State     string `json:"state"`
 								} `json:"nodes"`
 							} `json:"comments"`
 						} `json:"nodes"`
@@ -551,6 +555,7 @@ query($owner: String!, $repo: String!, $prNumber: Int!,
 				Author:    comment.Author.Login,
 				Body:      comment.Body,
 				CreatedAt: comment.CreatedAt,
+				State:     comment.State,
 			})
 
 			lastReplier = comment.Author.Login


### PR DESCRIPTION
## Summary
- Implement auto-submit functionality for review comments to prevent them from remaining in pending state
- Add detection and warning system for pending comments
- Provide manual submit command for bulk operations

## Problem
When using `threads reply` command, review comments were created in PENDING state and not automatically submitted. This caused confusion as seen in https://github.com/apstndb/spanner-mycli/pull/453#discussion_r2282582534 where comments appeared as "Pending" in the GitHub UI despite being intended as posted.

## Solution
1. **Auto-submit by default**: Modified `ReplyToThread` to automatically submit reviews after adding comments
2. **Pending detection**: Enhanced `reviews fetch` to detect and warn about pending comments
3. **Manual control**: Added `--no-submit` flag for rare cases where pending comments are desired
4. **Bulk submit**: New `threads submit` command to publish all pending reviews at once

## Changes
- Modified `threads.go`: Added auto-submit logic to `ReplyToThread` method
- Added `graphql_types.go`: SubmitPullRequestReview mutation types
- Enhanced `reviews_unified.go`: Pending comment detection and warnings
- Updated `unified_graphql.go`: Added `state` field to comment fragments
- New command `threads submit`: Bulk submit pending reviews
- Updated CLAUDE.md: Documentation for new workflow

## Testing
- ✅ Built successfully with `make build`
- ✅ All tests pass with `make test`
- ✅ No linting issues with `make lint`
- ✅ Full check passes with `make check`

## Usage Examples
```bash
# Default behavior - auto-submits (no more pending)
./bin/gh-helper threads reply PRRT_xxx --message "Fixed as suggested" --resolve

# Rare: Create pending comment
./bin/gh-helper threads reply PRRT_xxx --message "Draft response" --no-submit

# Detect pending comments
./bin/gh-helper reviews fetch 453
# Output: ⚠️ Found X pending comment(s). Use 'threads submit' to publish them.

# Submit all pending comments
./bin/gh-helper threads submit 453
```

## Breaking Changes
None. The default behavior change (auto-submit) is a improvement that prevents the confusing "pending" state. Users who specifically want pending comments can use `--no-submit`.

🤖 Generated with [Claude Code](https://claude.ai/code)