### PR TITLE
Add bot review status command

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,39 @@
+# gh-dev-tools Gemini Code Review Style Guide
+
+## Repository Context
+
+gh-dev-tools is a Go repository for GitHub development tooling. Prefer findings
+that identify concrete correctness, security, reliability, maintainability, or
+workflow consistency risks in this repository.
+
+## Review Calibration
+
+- Do not flag a dependency or tool version as invalid solely because it is newer
+  than the model's training data. Modern tools may have releases that postdate
+  the model's knowledge cutoff.
+- If a version is specified in repository tooling such as `mise.toml`, treat the
+  repository's validation commands as authoritative when they prove the version
+  resolves and runs. For this repository, `make check` runs `mise install` and
+  `mise exec -- golangci-lint`.
+- Do not recommend downgrading `golangci-lint` from a valid v2 release to an
+  older v1 release unless repository validation fails or the change is directly
+  required by compatibility evidence in the PR.
+- Avoid comments that only restate generic style preferences when the existing
+  code follows a deliberate local pattern and has focused test coverage.
+
+## Tooling Expectations
+
+- Local and CI linting should use the same repo-pinned toolchain. Prefer
+  `make lint`/`make check` over separate ad hoc `golangci-lint` invocations.
+- `mise.toml` is the source of truth for developer tool versions used by
+  `make lint`.
+- `gh-helper` may use both REST and GraphQL GitHub APIs. Prefer feedback that
+  preserves explicit backend choice, rate-limit awareness, and structured output.
+
+## GitHub Review Workflow
+
+- For `/gemini review` slash-command triggers, a top-level PR conversation
+  comment created through the REST issue-comments API is acceptable and preferred
+  when it avoids unnecessary GraphQL budget.
+- For thread reply and resolve operations, GraphQL is expected because GitHub's
+  review-thread operations are GraphQL-oriented.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,11 @@ jobs:
       with:
         go-version: '1.24'
 
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v6
-      with:
-        version: latest
-        args: --timeout=5m
+    - name: Set up mise
+      uses: jdx/mise-action@v2
+
+    - name: Run lint
+      run: make lint
 
   build:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 MISE ?= mise
 MISE_CONFIG := $(CURDIR)/mise.toml
-MISE_ENV := MISE_TRUSTED_CONFIG_PATHS=$(MISE_CONFIG)
+MISE_ENV := MISE_TRUSTED_CONFIG_PATHS="$(MISE_CONFIG)"
 GOLANGCI_LINT ?= $(MISE) exec -- golangci-lint
 
 build:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 # gh-dev-tools Makefile
 # Generic GitHub development tools optimized for AI assistants
 
+MISE ?= mise
+MISE_CONFIG := $(CURDIR)/mise.toml
+MISE_ENV := MISE_TRUSTED_CONFIG_PATHS=$(MISE_CONFIG)
+GOLANGCI_LINT ?= $(MISE) exec -- golangci-lint
+
 build:
 	mkdir -p bin
 	go build -o bin/gh-helper ./gh-helper
@@ -23,7 +28,8 @@ test-quick:
 	go test -short ./...
 
 lint:
-	golangci-lint run
+	$(MISE_ENV) $(MISE) install
+	cd gh-helper && $(MISE_ENV) $(GOLANGCI_LINT) run --timeout=5m
 
 # Combined test and lint check (required before push)
 check: test lint

--- a/gh-helper/README.md
+++ b/gh-helper/README.md
@@ -8,6 +8,9 @@ Generic GitHub operations tool optimized for AI assistants.
 # Most common: Complete review workflow
 gh-helper reviews wait [PR] --request-review
 
+# Check whether Copilot/Gemini already reviewed the current PR head
+gh-helper reviews bot-status [PR]
+
 # Handle review feedback with structured output
 gh-helper reviews analyze [PR] | gojq --yaml-input '.threadsNeedingReply[]'
 gh-helper threads reply <THREAD_ID> --message "Fixed in commit abc123"
@@ -86,7 +89,11 @@ reviews wait [PR] --exclude-reviews   # Checks only
 
 # Monitoring and checking
 reviews check [PR]                    # One-time check (uses current branch if omitted)
+reviews bot-status [PR]               # Bot review status for the current PR head
 ```
+
+`reviews wait --request-review` checks the current PR head first and skips posting
+`/gemini review` when Gemini has already reviewed that commit.
 
 ### threads
 
@@ -416,8 +423,9 @@ gh-helper threads show PRRT_kwDONC6gMM5SU-GH
 gh-helper threads reply PRRT_kwDONC6gMM5SU-GH --commit-hash abc1234 \
   --message "Fixed the error handling as suggested"
 
-# 6. Request follow-up review if needed
-gh pr comment 306 --body "/gemini review"
+# 6. Check bot status and request follow-up review if needed
+gh-helper reviews bot-status 306
+gh-helper reviews wait 306 --request-review
 ```
 
 ### AI Assistant Usage

--- a/gh-helper/README.md
+++ b/gh-helper/README.md
@@ -93,7 +93,9 @@ reviews bot-status [PR]               # Bot review status for the current PR hea
 ```
 
 `reviews wait --request-review` checks the current PR head first and skips posting
-`/gemini review` when Gemini has already reviewed that commit.
+`/gemini review` when Gemini has already reviewed that commit. When it does
+request Gemini, it posts the slash-command through the REST issue-comments API
+to avoid spending GraphQL budget on a top-level PR conversation comment.
 
 ### threads
 

--- a/gh-helper/bot_status.go
+++ b/gh-helper/bot_status.go
@@ -18,6 +18,7 @@ const (
 	geminiReviewBotLogin  = "gemini-code-assist"
 	maxBotReviewPages     = 20
 	maxBotThreadPages     = 20
+	maxGitRefLineSize     = 1024 * 1024
 )
 
 //go:embed queries/bot_review_metadata.graphql
@@ -775,6 +776,7 @@ func readGitRef(root string, ref string) string {
 	}()
 
 	scanner := bufio.NewScanner(packedRefs)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxGitRefLineSize)
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.HasPrefix(line, "#") || strings.HasPrefix(line, "^") {

--- a/gh-helper/bot_status.go
+++ b/gh-helper/bot_status.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	copilotReviewBotLogin = "copilot-pull-request-reviewer[bot]"
-	geminiReviewBotLogin  = "gemini-code-assist[bot]"
+	copilotReviewBotLogin = "copilot-pull-request-reviewer"
+	geminiReviewBotLogin  = "gemini-code-assist"
 )
 
 var botStatusCmd = &cobra.Command{
@@ -57,6 +57,8 @@ type ReviewBotStatus struct {
 	LatestCurrentHeadReviewID    string             `json:"latestCurrentHeadReviewId,omitempty"`
 	LatestCurrentHeadReviewState string             `json:"latestCurrentHeadReviewState,omitempty"`
 	UnresolvedCurrentHeadThreads []BotThreadSummary `json:"unresolvedCurrentHeadThreads"`
+	UnresolvedOtherThreads       []BotThreadSummary `json:"unresolvedOtherThreads"`
+	ReviewDataIncomplete         bool               `json:"reviewDataIncomplete"`
 	NextAction                   string             `json:"nextAction"`
 }
 
@@ -66,6 +68,7 @@ type BotThreadSummary struct {
 	Line        *int   `json:"line"`
 	IsOutdated  bool   `json:"isOutdated"`
 	Author      string `json:"author"`
+	CommitOID   string `json:"commitOid,omitempty"`
 	CreatedAt   string `json:"createdAt"`
 	BodyPreview string `json:"bodyPreview"`
 }
@@ -85,6 +88,7 @@ type botThreadNode struct {
 	Line       *int
 	IsResolved bool
 	IsOutdated bool
+	Truncated  bool
 	Comments   []botThreadComment
 }
 
@@ -94,6 +98,69 @@ type botThreadComment struct {
 	CreatedAt string
 	State     string
 	CommitOID string
+}
+
+type botReviewStatusResponse struct {
+	Data struct {
+		Repository struct {
+			PullRequest struct {
+				Number  int    `json:"number"`
+				Title   string `json:"title"`
+				Commits struct {
+					Nodes []struct {
+						Commit struct {
+							OID string `json:"oid"`
+						} `json:"commit"`
+					} `json:"nodes"`
+				} `json:"commits"`
+				Reviews struct {
+					Nodes []struct {
+						ID     string `json:"id"`
+						Author struct {
+							Login string `json:"login"`
+						} `json:"author"`
+						State     string `json:"state"`
+						Body      string `json:"body"`
+						CreatedAt string `json:"createdAt"`
+						Commit    struct {
+							OID string `json:"oid"`
+						} `json:"commit"`
+					} `json:"nodes"`
+				} `json:"reviews"`
+				ReviewThreads struct {
+					PageInfo struct {
+						HasNextPage bool   `json:"hasNextPage"`
+						EndCursor   string `json:"endCursor"`
+					} `json:"pageInfo"`
+					Nodes []struct {
+						ID         string `json:"id"`
+						Path       string `json:"path"`
+						Line       *int   `json:"line"`
+						IsResolved bool   `json:"isResolved"`
+						IsOutdated bool   `json:"isOutdated"`
+						Comments   struct {
+							PageInfo struct {
+								HasNextPage bool `json:"hasNextPage"`
+							} `json:"pageInfo"`
+							Nodes []struct {
+								Body      string `json:"body"`
+								CreatedAt string `json:"createdAt"`
+								State     string `json:"state"`
+								Author    struct {
+									Login string `json:"login"`
+								} `json:"author"`
+								PullRequestReview struct {
+									Commit struct {
+										OID string `json:"oid"`
+									} `json:"commit"`
+								} `json:"pullRequestReview"`
+							} `json:"nodes"`
+						} `json:"comments"`
+					} `json:"nodes"`
+				} `json:"reviewThreads"`
+			} `json:"pullRequest"`
+		} `json:"repository"`
+	} `json:"data"`
 }
 
 func showBotStatus(cmd *cobra.Command, args []string) error {
@@ -120,7 +187,7 @@ func (c *GitHubClient) GetBotReviewReport(prNumber string) (*BotReviewReport, er
 	}
 
 	query := `
-query($owner: String!, $repo: String!, $prNumber: Int!) {
+query($owner: String!, $repo: String!, $prNumber: Int!, $threadAfter: String) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $prNumber) {
       number
@@ -144,7 +211,7 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
           }
         }
       }
-      reviewThreads(first: 100) {
+      reviewThreads(first: 100, after: $threadAfter) {
         nodes {
           id
           path
@@ -152,6 +219,9 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
           isResolved
           isOutdated
           comments(first: 100) {
+            pageInfo {
+              hasNextPage
+            }
             nodes {
               body
               createdAt
@@ -167,84 +237,54 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
         }
         pageInfo {
           hasNextPage
+          endCursor
         }
       }
     }
   }
 }`
 
-	variables := map[string]interface{}{
-		"owner":    c.Owner,
-		"repo":     c.Repo,
-		"prNumber": prNumberInt,
-	}
+	var response botReviewStatusResponse
+	threads := []botThreadNode{}
+	threadsTruncated := false
+	threadAfter := ""
+	for {
+		variables := map[string]interface{}{
+			"owner":       c.Owner,
+			"repo":        c.Repo,
+			"prNumber":    prNumberInt,
+			"threadAfter": nil,
+		}
+		if threadAfter != "" {
+			variables["threadAfter"] = threadAfter
+		}
 
-	result, err := c.RunGraphQLQueryWithVariables(query, variables)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch bot review status: %w", err)
-	}
+		result, err := c.RunGraphQLQueryWithVariables(query, variables)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch bot review status: %w", err)
+		}
 
-	var response struct {
-		Data struct {
-			Repository struct {
-				PullRequest struct {
-					Number  int    `json:"number"`
-					Title   string `json:"title"`
-					Commits struct {
-						Nodes []struct {
-							Commit struct {
-								OID string `json:"oid"`
-							} `json:"commit"`
-						} `json:"nodes"`
-					} `json:"commits"`
-					Reviews struct {
-						Nodes []struct {
-							ID     string `json:"id"`
-							Author struct {
-								Login string `json:"login"`
-							} `json:"author"`
-							State     string `json:"state"`
-							Body      string `json:"body"`
-							CreatedAt string `json:"createdAt"`
-							Commit    struct {
-								OID string `json:"oid"`
-							} `json:"commit"`
-						} `json:"nodes"`
-					} `json:"reviews"`
-					ReviewThreads struct {
-						PageInfo struct {
-							HasNextPage bool `json:"hasNextPage"`
-						} `json:"pageInfo"`
-						Nodes []struct {
-							ID         string `json:"id"`
-							Path       string `json:"path"`
-							Line       *int   `json:"line"`
-							IsResolved bool   `json:"isResolved"`
-							IsOutdated bool   `json:"isOutdated"`
-							Comments   struct {
-								Nodes []struct {
-									Body      string `json:"body"`
-									CreatedAt string `json:"createdAt"`
-									State     string `json:"state"`
-									Author    struct {
-										Login string `json:"login"`
-									} `json:"author"`
-									PullRequestReview struct {
-										Commit struct {
-											OID string `json:"oid"`
-										} `json:"commit"`
-									} `json:"pullRequestReview"`
-								} `json:"nodes"`
-							} `json:"comments"`
-						} `json:"nodes"`
-					} `json:"reviewThreads"`
-				} `json:"pullRequest"`
-			} `json:"repository"`
-		} `json:"data"`
-	}
+		var pageResponse botReviewStatusResponse
+		if err := Unmarshal(result, &pageResponse); err != nil {
+			return nil, fmt.Errorf("failed to parse bot review status: %w", err)
+		}
+		if response.Data.Repository.PullRequest.Number == 0 {
+			response = pageResponse
+		}
 
-	if err := Unmarshal(result, &response); err != nil {
-		return nil, fmt.Errorf("failed to parse bot review status: %w", err)
+		pageThreads, pageTruncated := botThreadNodesFromResponse(pageResponse)
+		threads = append(threads, pageThreads...)
+		threadsTruncated = threadsTruncated || pageTruncated
+
+		pageInfo := pageResponse.Data.Repository.PullRequest.ReviewThreads.PageInfo
+		if !pageInfo.HasNextPage {
+			break
+		}
+		if pageInfo.EndCursor == "" {
+			threadsTruncated = true
+			break
+		}
+		threadAfter = pageInfo.EndCursor
 	}
 
 	pr := response.Data.Repository.PullRequest
@@ -265,7 +305,22 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
 		})
 	}
 
+	localHeadOID := localGitHeadOID()
+	return buildBotReviewReport(
+		pr.Number,
+		pr.Title,
+		prHeadOID,
+		localHeadOID,
+		reviews,
+		threads,
+		threadsTruncated,
+	), nil
+}
+
+func botThreadNodesFromResponse(response botReviewStatusResponse) ([]botThreadNode, bool) {
+	pr := response.Data.Repository.PullRequest
 	threads := make([]botThreadNode, 0, len(pr.ReviewThreads.Nodes))
+	threadsTruncated := false
 	for _, thread := range pr.ReviewThreads.Nodes {
 		comments := make([]botThreadComment, 0, len(thread.Comments.Nodes))
 		for _, comment := range thread.Comments.Nodes {
@@ -277,20 +332,19 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
 				CommitOID: comment.PullRequestReview.Commit.OID,
 			})
 		}
+		commentsTruncated := thread.Comments.PageInfo.HasNextPage
+		threadsTruncated = threadsTruncated || commentsTruncated
 		threads = append(threads, botThreadNode{
 			ID:         thread.ID,
 			Path:       thread.Path,
 			Line:       thread.Line,
 			IsResolved: thread.IsResolved,
 			IsOutdated: thread.IsOutdated,
+			Truncated:  commentsTruncated,
 			Comments:   comments,
 		})
 	}
-
-	localHeadOID := localGitHeadOID()
-	report := buildBotReviewReport(pr.Number, pr.Title, prHeadOID, localHeadOID, reviews, threads)
-	report.ThreadsTruncated = pr.ReviewThreads.PageInfo.HasNextPage
-	return report, nil
+	return threads, threadsTruncated
 }
 
 func buildBotReviewReport(
@@ -300,10 +354,11 @@ func buildBotReviewReport(
 	localHeadOID string,
 	reviews []botReviewNode,
 	threads []botThreadNode,
+	threadsTruncated bool,
 ) *BotReviewReport {
 	bots := []ReviewBotStatus{
-		buildReviewBotStatus("copilot", copilotReviewBotLogin, prHeadOID, reviews, threads),
-		buildReviewBotStatus("gemini", geminiReviewBotLogin, prHeadOID, reviews, threads),
+		buildReviewBotStatus("copilot", copilotReviewBotLogin, prHeadOID, reviews, threads, threadsTruncated),
+		buildReviewBotStatus("gemini", geminiReviewBotLogin, prHeadOID, reviews, threads, threadsTruncated),
 	}
 
 	return &BotReviewReport{
@@ -312,6 +367,7 @@ func buildBotReviewReport(
 		PRHeadOID:          prHeadOID,
 		LocalHeadOID:       localHeadOID,
 		LocalHeadMatchesPR: localHeadOID != "" && prHeadOID != "" && localHeadOID == prHeadOID,
+		ThreadsTruncated:   threadsTruncated,
 		Bots:               bots,
 	}
 }
@@ -322,12 +378,13 @@ func buildReviewBotStatus(
 	headOID string,
 	reviews []botReviewNode,
 	threads []botThreadNode,
+	reviewDataIncomplete bool,
 ) ReviewBotStatus {
 	var latest *botReviewNode
 	var latestCurrentHead *botReviewNode
 	for i := range reviews {
 		review := &reviews[i]
-		if review.Author != login || !isRelevantBotReview(login, review.Body) {
+		if !botLoginMatches(review.Author, login) || !isRelevantBotReview(login, review.Body) {
 			continue
 		}
 		if latest == nil || review.CreatedAt > latest.CreatedAt {
@@ -338,12 +395,14 @@ func buildReviewBotStatus(
 		}
 	}
 
-	unresolvedThreads := unresolvedBotThreads(login, headOID, threads)
+	currentHeadThreads, otherThreads := unresolvedBotThreads(login, headOID, threads)
 	status := ReviewBotStatus{
 		Bot:                          bot,
 		Login:                        login,
 		ReviewedCurrentHead:          latestCurrentHead != nil,
-		UnresolvedCurrentHeadThreads: unresolvedThreads,
+		UnresolvedCurrentHeadThreads: currentHeadThreads,
+		UnresolvedOtherThreads:       otherThreads,
+		ReviewDataIncomplete:         reviewDataIncomplete,
 	}
 
 	if latest != nil {
@@ -358,23 +417,38 @@ func buildReviewBotStatus(
 		status.PositiveSignal = positiveBotReviewSignal(login, latestCurrentHead.Body)
 	}
 
-	status.Ready = botReady(login, status.ReviewedCurrentHead, status.PositiveSignal, unresolvedThreads)
+	status.Ready = botReady(
+		login,
+		status.ReviewedCurrentHead,
+		status.PositiveSignal,
+		currentHeadThreads,
+		otherThreads,
+		reviewDataIncomplete,
+	)
 	status.NextAction = botNextAction(bot, status)
 	return status
 }
 
-func botReady(login string, reviewedCurrentHead bool, positiveSignal string, unresolvedThreads []BotThreadSummary) bool {
-	if !reviewedCurrentHead || len(unresolvedThreads) > 0 {
+func botReady(
+	login string,
+	reviewedCurrentHead bool,
+	positiveSignal string,
+	currentHeadThreads []BotThreadSummary,
+	otherThreads []BotThreadSummary,
+	reviewDataIncomplete bool,
+) bool {
+	if !reviewedCurrentHead || len(currentHeadThreads) > 0 || len(otherThreads) > 0 || reviewDataIncomplete {
 		return false
 	}
 	if login == geminiReviewBotLogin {
 		return positiveSignal != ""
 	}
-	return positiveSignal != "" || len(unresolvedThreads) == 0
+	return true
 }
 
-func unresolvedBotThreads(login string, headOID string, threads []botThreadNode) []BotThreadSummary {
-	summaries := []BotThreadSummary{}
+func unresolvedBotThreads(login string, headOID string, threads []botThreadNode) ([]BotThreadSummary, []BotThreadSummary) {
+	currentHeadSummaries := []BotThreadSummary{}
+	otherSummaries := []BotThreadSummary{}
 	for _, thread := range threads {
 		if thread.IsResolved {
 			continue
@@ -383,7 +457,7 @@ func unresolvedBotThreads(login string, headOID string, threads []botThreadNode)
 		var botComment *botThreadComment
 		for i := range thread.Comments {
 			comment := &thread.Comments[i]
-			if comment.Author == login && comment.CommitOID == headOID {
+			if botLoginMatches(comment.Author, login) {
 				botComment = comment
 			}
 		}
@@ -391,27 +465,32 @@ func unresolvedBotThreads(login string, headOID string, threads []botThreadNode)
 			continue
 		}
 
-		summaries = append(summaries, BotThreadSummary{
+		summary := BotThreadSummary{
 			ID:          thread.ID,
 			Path:        thread.Path,
 			Line:        thread.Line,
 			IsOutdated:  thread.IsOutdated,
 			Author:      botComment.Author,
+			CommitOID:   botComment.CommitOID,
 			CreatedAt:   botComment.CreatedAt,
 			BodyPreview: truncateForStatus(botComment.Body, 160),
-		})
+		}
+		if botComment.CommitOID == headOID {
+			currentHeadSummaries = append(currentHeadSummaries, summary)
+			continue
+		}
+		otherSummaries = append(otherSummaries, summary)
 	}
-	return summaries
+	return currentHeadSummaries, otherSummaries
 }
 
 func isRelevantBotReview(login string, body string) bool {
 	if login != geminiReviewBotLogin {
 		return true
 	}
-	if strings.Contains(body, geminiReviewHeader) {
-		return true
-	}
-	return strings.Contains(body, "I have no feedback to provide.")
+	return !strings.Contains(body, geminiSummaryHeader) ||
+		strings.Contains(body, geminiReviewHeader) ||
+		strings.Contains(body, "I have no feedback to provide.")
 }
 
 func positiveBotReviewSignal(login string, body string) string {
@@ -433,6 +512,12 @@ func botNextAction(bot string, status ReviewBotStatus) string {
 	if len(status.UnresolvedCurrentHeadThreads) > 0 {
 		return "address, reply to, and resolve the unresolved current-head threads"
 	}
+	if len(status.UnresolvedOtherThreads) > 0 {
+		return "address, reply to, and resolve unresolved threads from earlier commits"
+	}
+	if status.ReviewDataIncomplete {
+		return "review thread data is incomplete because at least one thread has more than 100 comments"
+	}
 	if status.Ready {
 		return "no action needed for the current PR head"
 	}
@@ -443,6 +528,14 @@ func botNextAction(bot string, status ReviewBotStatus) string {
 		return "request Gemini review for the current PR head"
 	}
 	return "request Copilot review for the current PR head"
+}
+
+func botLoginMatches(actual string, expected string) bool {
+	return normalizeBotLogin(actual) == normalizeBotLogin(expected)
+}
+
+func normalizeBotLogin(login string) string {
+	return strings.TrimSuffix(login, "[bot]")
 }
 
 func requestGeminiReviewForCurrentHead(client *GitHubClient, prNumber string) error {

--- a/gh-helper/bot_status.go
+++ b/gh-helper/bot_status.go
@@ -708,7 +708,11 @@ func requestGeminiReviewForCurrentHead(client *GitHubClient, prNumber string) er
 }
 
 func localGitHeadOID() string {
-	cmd := exec.Command("git", "rev-parse", "HEAD")
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		return ""
+	}
+	cmd := exec.Command(gitPath, "rev-parse", "HEAD")
 	output, err := cmd.Output()
 	if err != nil {
 		return ""

--- a/gh-helper/bot_status.go
+++ b/gh-helper/bot_status.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	_ "embed"
 	"fmt"
+	"log/slog"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -15,6 +17,12 @@ const (
 	maxBotReviewPages     = 20
 	maxBotThreadPages     = 20
 )
+
+//go:embed queries/bot_review_metadata.graphql
+var botReviewMetadataQuery string
+
+//go:embed queries/bot_review_threads.graphql
+var botReviewThreadsQuery string
 
 var botStatusCmd = &cobra.Command{
 	Use:   "bot-status [pr-number]",
@@ -241,39 +249,6 @@ func (c *GitHubClient) GetBotReviewReport(prNumber string) (*BotReviewReport, er
 }
 
 func (c *GitHubClient) fetchBotReviewMetadata(prNumberInt int) (*botReviewMetadata, error) {
-	query := `
-query($owner: String!, $repo: String!, $prNumber: Int!, $reviewBefore: String) {
-  repository(owner: $owner, name: $repo) {
-    pullRequest(number: $prNumber) {
-      number
-      title
-      commits(last: 1) {
-        nodes {
-          commit {
-            oid
-          }
-        }
-      }
-      reviews(last: 100, before: $reviewBefore) {
-        pageInfo {
-          hasPreviousPage
-          startCursor
-        }
-        nodes {
-          id
-          author { login }
-          state
-          body
-          createdAt
-          commit {
-            oid
-          }
-        }
-      }
-    }
-  }
-}`
-
 	metadata := &botReviewMetadata{}
 	reviewBefore := ""
 	for page := 0; ; page++ {
@@ -287,7 +262,7 @@ query($owner: String!, $repo: String!, $prNumber: Int!, $reviewBefore: String) {
 			variables["reviewBefore"] = reviewBefore
 		}
 
-		result, err := c.RunGraphQLQueryWithVariables(query, variables)
+		result, err := c.RunGraphQLQueryWithVariables(botReviewMetadataQuery, variables)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch bot review metadata: %w", err)
 		}
@@ -335,43 +310,6 @@ query($owner: String!, $repo: String!, $prNumber: Int!, $reviewBefore: String) {
 }
 
 func (c *GitHubClient) fetchBotReviewThreads(prNumberInt int) ([]botThreadNode, bool, error) {
-	query := `
-query($owner: String!, $repo: String!, $prNumber: Int!, $threadAfter: String) {
-  repository(owner: $owner, name: $repo) {
-    pullRequest(number: $prNumber) {
-      reviewThreads(first: 100, after: $threadAfter) {
-        nodes {
-          id
-          path
-          line
-          isResolved
-          isOutdated
-          comments(first: 100) {
-            pageInfo {
-              hasNextPage
-            }
-            nodes {
-              body
-              createdAt
-              state
-              author { login }
-              pullRequestReview {
-                commit {
-                  oid
-                }
-              }
-            }
-          }
-        }
-        pageInfo {
-          hasNextPage
-          endCursor
-        }
-      }
-    }
-  }
-}`
-
 	threads := []botThreadNode{}
 	threadsTruncated := false
 	threadAfter := ""
@@ -386,7 +324,7 @@ query($owner: String!, $repo: String!, $prNumber: Int!, $threadAfter: String) {
 			variables["threadAfter"] = threadAfter
 		}
 
-		result, err := c.RunGraphQLQueryWithVariables(query, variables)
+		result, err := c.RunGraphQLQueryWithVariables(botReviewThreadsQuery, variables)
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to fetch bot review threads: %w", err)
 		}
@@ -710,11 +648,13 @@ func requestGeminiReviewForCurrentHead(client *GitHubClient, prNumber string) er
 func localGitHeadOID() string {
 	gitPath, err := exec.LookPath("git")
 	if err != nil {
+		slog.Debug("git command not found, cannot get local HEAD OID", "error", err)
 		return ""
 	}
 	cmd := exec.Command(gitPath, "rev-parse", "HEAD")
 	output, err := cmd.Output()
 	if err != nil {
+		slog.Debug("failed to get local HEAD OID", "error", err)
 		return ""
 	}
 	return strings.TrimSpace(string(output))

--- a/gh-helper/bot_status.go
+++ b/gh-helper/bot_status.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	_ "embed"
 	"fmt"
 	"log/slog"
@@ -766,11 +767,19 @@ func readGitRef(root string, ref string) string {
 		}
 	}
 
-	packedRefs, err := os.ReadFile(filepath.Join(root, "packed-refs"))
+	packedRefs, err := os.Open(filepath.Join(root, "packed-refs"))
 	if err != nil {
 		return ""
 	}
-	for _, line := range strings.Split(string(packedRefs), "\n") {
+	defer func() {
+		if err := packedRefs.Close(); err != nil {
+			slog.Debug("failed to close packed-refs", "root", root, "error", err)
+		}
+	}()
+
+	scanner := bufio.NewScanner(packedRefs)
+	for scanner.Scan() {
+		line := scanner.Text()
 		if strings.HasPrefix(line, "#") || strings.HasPrefix(line, "^") {
 			continue
 		}
@@ -778,6 +787,9 @@ func readGitRef(root string, ref string) string {
 		if ok && packedRef == ref && isGitOID(oid) {
 			return oid
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		slog.Debug("failed to scan packed-refs", "root", root, "error", err)
 	}
 	return ""
 }

--- a/gh-helper/bot_status.go
+++ b/gh-helper/bot_status.go
@@ -40,6 +40,7 @@ type BotReviewReport struct {
 	PRHeadOID          string            `json:"prHeadOid"`
 	LocalHeadOID       string            `json:"localHeadOid,omitempty"`
 	LocalHeadMatchesPR bool              `json:"localHeadMatchesPr"`
+	ReviewsTruncated   bool              `json:"reviewsTruncated"`
 	ThreadsTruncated   bool              `json:"threadsTruncated"`
 	Bots               []ReviewBotStatus `json:"bots"`
 }
@@ -49,6 +50,7 @@ type ReviewBotStatus struct {
 	Login                        string             `json:"login"`
 	ReviewedCurrentHead          bool               `json:"reviewedCurrentHead"`
 	Ready                        bool               `json:"ready"`
+	ReadinessPolicy              string             `json:"readinessPolicy"`
 	PositiveSignal               string             `json:"positiveSignal,omitempty"`
 	LatestReviewID               string             `json:"latestReviewId,omitempty"`
 	LatestReviewState            string             `json:"latestReviewState,omitempty"`
@@ -114,6 +116,9 @@ type botReviewStatusResponse struct {
 					} `json:"nodes"`
 				} `json:"commits"`
 				Reviews struct {
+					PageInfo struct {
+						HasPreviousPage bool `json:"hasPreviousPage"`
+					} `json:"pageInfo"`
 					Nodes []struct {
 						ID     string `json:"id"`
 						Author struct {
@@ -200,6 +205,9 @@ query($owner: String!, $repo: String!, $prNumber: Int!, $threadAfter: String) {
         }
       }
       reviews(last: 100) {
+        pageInfo {
+          hasPreviousPage
+        }
         nodes {
           id
           author { login }
@@ -306,6 +314,7 @@ query($owner: String!, $repo: String!, $prNumber: Int!, $threadAfter: String) {
 	}
 
 	localHeadOID := localGitHeadOID()
+	reviewsTruncated := pr.Reviews.PageInfo.HasPreviousPage
 	return buildBotReviewReport(
 		pr.Number,
 		pr.Title,
@@ -313,6 +322,7 @@ query($owner: String!, $repo: String!, $prNumber: Int!, $threadAfter: String) {
 		localHeadOID,
 		reviews,
 		threads,
+		reviewsTruncated,
 		threadsTruncated,
 	), nil
 }
@@ -354,11 +364,28 @@ func buildBotReviewReport(
 	localHeadOID string,
 	reviews []botReviewNode,
 	threads []botThreadNode,
+	reviewsTruncated bool,
 	threadsTruncated bool,
 ) *BotReviewReport {
 	bots := []ReviewBotStatus{
-		buildReviewBotStatus("copilot", copilotReviewBotLogin, prHeadOID, reviews, threads, threadsTruncated),
-		buildReviewBotStatus("gemini", geminiReviewBotLogin, prHeadOID, reviews, threads, threadsTruncated),
+		buildReviewBotStatus(
+			"copilot",
+			copilotReviewBotLogin,
+			prHeadOID,
+			reviews,
+			threads,
+			reviewsTruncated,
+			threadsTruncated,
+		),
+		buildReviewBotStatus(
+			"gemini",
+			geminiReviewBotLogin,
+			prHeadOID,
+			reviews,
+			threads,
+			reviewsTruncated,
+			threadsTruncated,
+		),
 	}
 
 	return &BotReviewReport{
@@ -367,6 +394,7 @@ func buildBotReviewReport(
 		PRHeadOID:          prHeadOID,
 		LocalHeadOID:       localHeadOID,
 		LocalHeadMatchesPR: localHeadOID != "" && prHeadOID != "" && localHeadOID == prHeadOID,
+		ReviewsTruncated:   reviewsTruncated,
 		ThreadsTruncated:   threadsTruncated,
 		Bots:               bots,
 	}
@@ -378,6 +406,7 @@ func buildReviewBotStatus(
 	headOID string,
 	reviews []botReviewNode,
 	threads []botThreadNode,
+	reviewsTruncated bool,
 	reviewDataIncomplete bool,
 ) ReviewBotStatus {
 	var latest *botReviewNode
@@ -400,9 +429,10 @@ func buildReviewBotStatus(
 		Bot:                          bot,
 		Login:                        login,
 		ReviewedCurrentHead:          latestCurrentHead != nil,
+		ReadinessPolicy:              readinessPolicy(login),
 		UnresolvedCurrentHeadThreads: currentHeadThreads,
 		UnresolvedOtherThreads:       otherThreads,
-		ReviewDataIncomplete:         reviewDataIncomplete,
+		ReviewDataIncomplete:         reviewDataIncomplete || (reviewsTruncated && latestCurrentHead == nil),
 	}
 
 	if latest != nil {
@@ -423,10 +453,17 @@ func buildReviewBotStatus(
 		status.PositiveSignal,
 		currentHeadThreads,
 		otherThreads,
-		reviewDataIncomplete,
+		status.ReviewDataIncomplete,
 	)
 	status.NextAction = botNextAction(bot, status)
 	return status
+}
+
+func readinessPolicy(login string) string {
+	if login == geminiReviewBotLogin {
+		return "Gemini is ready only after a current-head no-feedback review and no unresolved Gemini threads."
+	}
+	return "Copilot is ready after any current-head review and no unresolved Copilot threads."
 }
 
 func botReady(

--- a/gh-helper/bot_status.go
+++ b/gh-helper/bot_status.go
@@ -516,7 +516,7 @@ func botNextAction(bot string, status ReviewBotStatus) string {
 		return "address, reply to, and resolve unresolved threads from earlier commits"
 	}
 	if status.ReviewDataIncomplete {
-		return "review thread data is incomplete because at least one thread has more than 100 comments"
+		return "review thread/comment data is incomplete because pagination limits left some data truncated"
 	}
 	if status.Ready {
 		return "no action needed for the current PR head"

--- a/gh-helper/bot_status.go
+++ b/gh-helper/bot_status.go
@@ -663,33 +663,39 @@ func normalizeBotLogin(login string) string {
 }
 
 func requestGeminiReviewForCurrentHead(client *GitHubClient, prNumber string) error {
-	report, err := client.GetBotReviewReport(prNumber)
+	prNumberInt, err := strconv.Atoi(prNumber)
+	if err != nil {
+		return fmt.Errorf("invalid PR number format: %w", err)
+	}
+
+	metadata, err := client.fetchBotReviewMetadata(prNumberInt)
 	if err != nil {
 		return err
 	}
 
-	for _, bot := range report.Bots {
-		if bot.Login != geminiReviewBotLogin {
-			continue
-		}
-		if bot.ReviewedCurrentHead {
-			fmt.Printf("✅ Gemini already reviewed PR head %s; skipping duplicate request\n", report.PRHeadOID)
-			return nil
-		}
-		if bot.ReviewDataIncomplete {
-			return fmt.Errorf("cannot safely request Gemini review because bot review data is incomplete; inspect bot-status output or request /gemini review manually")
-		}
+	geminiStatus := buildReviewBotStatus(
+		"gemini",
+		geminiReviewBotLogin,
+		metadata.PRHeadOID,
+		metadata.Reviews,
+		nil,
+		botStatusCompleteness{ReviewsTruncated: metadata.ReviewsTruncated},
+	)
+	if geminiStatus.ReviewedCurrentHead {
+		fmt.Printf("✅ Gemini already reviewed PR head %s; skipping duplicate request\n", metadata.PRHeadOID)
+		return nil
 	}
 
-	if report.ReviewsTruncated {
+	if geminiStatus.ReviewDataIncomplete {
 		return fmt.Errorf("cannot safely request Gemini review because review history is incomplete; inspect bot-status output or request /gemini review manually")
 	}
 
-	if report.LocalHeadOID != "" && report.PRHeadOID != "" && !report.LocalHeadMatchesPR {
+	localHeadOID := localGitHeadOID()
+	if localHeadOID != "" && metadata.PRHeadOID != "" && localHeadOID != metadata.PRHeadOID {
 		fmt.Printf(
 			"⚠️  Local HEAD %s differs from PR head %s; requesting review for the pushed PR head\n",
-			report.LocalHeadOID,
-			report.PRHeadOID,
+			localHeadOID,
+			metadata.PRHeadOID,
 		)
 	}
 

--- a/gh-helper/bot_status.go
+++ b/gh-helper/bot_status.go
@@ -699,8 +699,8 @@ func requestGeminiReviewForCurrentHead(client *GitHubClient, prNumber string) er
 		)
 	}
 
-	fmt.Printf("📝 Requesting Gemini review for PR #%s...\n", prNumber)
-	if err := client.CreatePRComment(prNumber, "/gemini review"); err != nil {
+	fmt.Printf("📝 Requesting Gemini review for PR #%s via REST comment...\n", prNumber)
+	if err := client.CreatePRConversationCommentREST(prNumber, "/gemini review"); err != nil {
 		return fmt.Errorf("failed to request Gemini review: %w", err)
 	}
 	fmt.Println("✅ Gemini review requested")

--- a/gh-helper/bot_status.go
+++ b/gh-helper/bot_status.go
@@ -527,15 +527,12 @@ func unresolvedBotThreads(login string, headOID string, threads []botThreadNode)
 		if thread.IsResolved {
 			continue
 		}
-
-		var botComment *botThreadComment
-		for i := range thread.Comments {
-			comment := &thread.Comments[i]
-			if botLoginMatches(comment.Author, login) {
-				botComment = comment
-			}
+		if len(thread.Comments) == 0 {
+			continue
 		}
-		if botComment == nil {
+
+		firstComment := thread.Comments[0]
+		if !botLoginMatches(firstComment.Author, login) {
 			continue
 		}
 
@@ -544,12 +541,12 @@ func unresolvedBotThreads(login string, headOID string, threads []botThreadNode)
 			Path:        thread.Path,
 			Line:        thread.Line,
 			IsOutdated:  thread.IsOutdated,
-			Author:      botComment.Author,
-			CommitOID:   botComment.CommitOID,
-			CreatedAt:   botComment.CreatedAt,
-			BodyPreview: truncateForStatus(botComment.Body, 160),
+			Author:      firstComment.Author,
+			CommitOID:   firstComment.CommitOID,
+			CreatedAt:   firstComment.CreatedAt,
+			BodyPreview: truncateForStatus(firstComment.Body, 160),
 		}
-		if botComment.CommitOID == headOID {
+		if firstComment.CommitOID == headOID {
 			currentHeadSummaries = append(currentHeadSummaries, summary)
 			continue
 		}

--- a/gh-helper/bot_status.go
+++ b/gh-helper/bot_status.go
@@ -249,6 +249,13 @@ func (c *GitHubClient) GetBotReviewReport(prNumber string) (*BotReviewReport, er
 }
 
 func (c *GitHubClient) fetchBotReviewMetadata(prNumberInt int) (*botReviewMetadata, error) {
+	return c.fetchBotReviewMetadataUntil(prNumberInt, nil)
+}
+
+func (c *GitHubClient) fetchBotReviewMetadataUntil(
+	prNumberInt int,
+	shouldStop func(*botReviewMetadata) bool,
+) (*botReviewMetadata, error) {
 	metadata := &botReviewMetadata{}
 	reviewBefore := ""
 	for page := 0; ; page++ {
@@ -289,6 +296,9 @@ func (c *GitHubClient) fetchBotReviewMetadata(prNumberInt int) (*botReviewMetada
 				CreatedAt: review.CreatedAt,
 				CommitOID: review.Commit.OID,
 			})
+		}
+		if shouldStop != nil && shouldStop(metadata) {
+			return metadata, nil
 		}
 
 		pageInfo := pr.Reviews.PageInfo
@@ -606,7 +616,7 @@ func requestGeminiReviewForCurrentHead(client *GitHubClient, prNumber string) er
 		return fmt.Errorf("invalid PR number format: %w", err)
 	}
 
-	metadata, err := client.fetchBotReviewMetadata(prNumberInt)
+	metadata, err := client.fetchBotReviewMetadataUntil(prNumberInt, geminiReviewedCurrentHead)
 	if err != nil {
 		return err
 	}
@@ -643,6 +653,20 @@ func requestGeminiReviewForCurrentHead(client *GitHubClient, prNumber string) er
 	}
 	fmt.Println("✅ Gemini review requested")
 	return nil
+}
+
+func geminiReviewedCurrentHead(metadata *botReviewMetadata) bool {
+	if metadata.PRHeadOID == "" {
+		return false
+	}
+	return buildReviewBotStatus(
+		"gemini",
+		geminiReviewBotLogin,
+		metadata.PRHeadOID,
+		metadata.Reviews,
+		nil,
+		botStatusCompleteness{},
+	).ReviewedCurrentHead
 }
 
 func localGitHeadOID() string {

--- a/gh-helper/bot_status.go
+++ b/gh-helper/bot_status.go
@@ -12,6 +12,8 @@ import (
 const (
 	copilotReviewBotLogin = "copilot-pull-request-reviewer"
 	geminiReviewBotLogin  = "gemini-code-assist"
+	maxBotReviewPages     = 20
+	maxBotThreadPages     = 20
 )
 
 var botStatusCmd = &cobra.Command{
@@ -102,7 +104,20 @@ type botThreadComment struct {
 	CommitOID string
 }
 
-type botReviewStatusResponse struct {
+type botStatusCompleteness struct {
+	ReviewsTruncated bool
+	ThreadsTruncated bool
+}
+
+type botReviewMetadata struct {
+	Number           int
+	Title            string
+	PRHeadOID        string
+	Reviews          []botReviewNode
+	ReviewsTruncated bool
+}
+
+type botReviewMetadataResponse struct {
 	Data struct {
 		Repository struct {
 			PullRequest struct {
@@ -117,7 +132,8 @@ type botReviewStatusResponse struct {
 				} `json:"commits"`
 				Reviews struct {
 					PageInfo struct {
-						HasPreviousPage bool `json:"hasPreviousPage"`
+						HasPreviousPage bool   `json:"hasPreviousPage"`
+						StartCursor     string `json:"startCursor"`
 					} `json:"pageInfo"`
 					Nodes []struct {
 						ID     string `json:"id"`
@@ -132,6 +148,15 @@ type botReviewStatusResponse struct {
 						} `json:"commit"`
 					} `json:"nodes"`
 				} `json:"reviews"`
+			} `json:"pullRequest"`
+		} `json:"repository"`
+	} `json:"data"`
+}
+
+type botReviewThreadsResponse struct {
+	Data struct {
+		Repository struct {
+			PullRequest struct {
 				ReviewThreads struct {
 					PageInfo struct {
 						HasNextPage bool   `json:"hasNextPage"`
@@ -191,8 +216,33 @@ func (c *GitHubClient) GetBotReviewReport(prNumber string) (*BotReviewReport, er
 		return nil, fmt.Errorf("invalid PR number format: %w", err)
 	}
 
+	metadata, err := c.fetchBotReviewMetadata(prNumberInt)
+	if err != nil {
+		return nil, err
+	}
+	threads, threadsTruncated, err := c.fetchBotReviewThreads(prNumberInt)
+	if err != nil {
+		return nil, err
+	}
+
+	localHeadOID := localGitHeadOID()
+	return buildBotReviewReport(
+		metadata.Number,
+		metadata.Title,
+		metadata.PRHeadOID,
+		localHeadOID,
+		metadata.Reviews,
+		threads,
+		botStatusCompleteness{
+			ReviewsTruncated: metadata.ReviewsTruncated,
+			ThreadsTruncated: threadsTruncated,
+		},
+	), nil
+}
+
+func (c *GitHubClient) fetchBotReviewMetadata(prNumberInt int) (*botReviewMetadata, error) {
 	query := `
-query($owner: String!, $repo: String!, $prNumber: Int!, $threadAfter: String) {
+query($owner: String!, $repo: String!, $prNumber: Int!, $reviewBefore: String) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $prNumber) {
       number
@@ -204,9 +254,10 @@ query($owner: String!, $repo: String!, $prNumber: Int!, $threadAfter: String) {
           }
         }
       }
-      reviews(last: 100) {
+      reviews(last: 100, before: $reviewBefore) {
         pageInfo {
           hasPreviousPage
+          startCursor
         }
         nodes {
           id
@@ -219,6 +270,75 @@ query($owner: String!, $repo: String!, $prNumber: Int!, $threadAfter: String) {
           }
         }
       }
+    }
+  }
+}`
+
+	metadata := &botReviewMetadata{}
+	reviewBefore := ""
+	for page := 0; ; page++ {
+		variables := map[string]interface{}{
+			"owner":        c.Owner,
+			"repo":         c.Repo,
+			"prNumber":     prNumberInt,
+			"reviewBefore": nil,
+		}
+		if reviewBefore != "" {
+			variables["reviewBefore"] = reviewBefore
+		}
+
+		result, err := c.RunGraphQLQueryWithVariables(query, variables)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch bot review metadata: %w", err)
+		}
+
+		var response botReviewMetadataResponse
+		if err := Unmarshal(result, &response); err != nil {
+			return nil, fmt.Errorf("failed to parse bot review metadata: %w", err)
+		}
+
+		pr := response.Data.Repository.PullRequest
+		if metadata.Number == 0 {
+			metadata.Number = pr.Number
+			metadata.Title = pr.Title
+			if len(pr.Commits.Nodes) > 0 {
+				metadata.PRHeadOID = pr.Commits.Nodes[0].Commit.OID
+			}
+		}
+		for _, review := range pr.Reviews.Nodes {
+			metadata.Reviews = append(metadata.Reviews, botReviewNode{
+				ID:        review.ID,
+				Author:    review.Author.Login,
+				State:     review.State,
+				Body:      review.Body,
+				CreatedAt: review.CreatedAt,
+				CommitOID: review.Commit.OID,
+			})
+		}
+
+		pageInfo := pr.Reviews.PageInfo
+		if !pageInfo.HasPreviousPage {
+			break
+		}
+		if pageInfo.StartCursor == "" {
+			metadata.ReviewsTruncated = true
+			break
+		}
+		if page+1 >= maxBotReviewPages {
+			metadata.ReviewsTruncated = true
+			break
+		}
+		reviewBefore = pageInfo.StartCursor
+	}
+
+	return metadata, nil
+}
+
+func (c *GitHubClient) fetchBotReviewThreads(prNumberInt int) ([]botThreadNode, bool, error) {
+	query := `
+query($owner: String!, $repo: String!, $prNumber: Int!, $threadAfter: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $prNumber) {
       reviewThreads(first: 100, after: $threadAfter) {
         nodes {
           id
@@ -252,11 +372,10 @@ query($owner: String!, $repo: String!, $prNumber: Int!, $threadAfter: String) {
   }
 }`
 
-	var response botReviewStatusResponse
 	threads := []botThreadNode{}
 	threadsTruncated := false
 	threadAfter := ""
-	for {
+	for page := 0; ; page++ {
 		variables := map[string]interface{}{
 			"owner":       c.Owner,
 			"repo":        c.Repo,
@@ -269,15 +388,12 @@ query($owner: String!, $repo: String!, $prNumber: Int!, $threadAfter: String) {
 
 		result, err := c.RunGraphQLQueryWithVariables(query, variables)
 		if err != nil {
-			return nil, fmt.Errorf("failed to fetch bot review status: %w", err)
+			return nil, false, fmt.Errorf("failed to fetch bot review threads: %w", err)
 		}
 
-		var pageResponse botReviewStatusResponse
+		var pageResponse botReviewThreadsResponse
 		if err := Unmarshal(result, &pageResponse); err != nil {
-			return nil, fmt.Errorf("failed to parse bot review status: %w", err)
-		}
-		if response.Data.Repository.PullRequest.Number == 0 {
-			response = pageResponse
+			return nil, false, fmt.Errorf("failed to parse bot review threads: %w", err)
 		}
 
 		pageThreads, pageTruncated := botThreadNodesFromResponse(pageResponse)
@@ -292,42 +408,17 @@ query($owner: String!, $repo: String!, $prNumber: Int!, $threadAfter: String) {
 			threadsTruncated = true
 			break
 		}
+		if page+1 >= maxBotThreadPages {
+			threadsTruncated = true
+			break
+		}
 		threadAfter = pageInfo.EndCursor
 	}
 
-	pr := response.Data.Repository.PullRequest
-	prHeadOID := ""
-	if len(pr.Commits.Nodes) > 0 {
-		prHeadOID = pr.Commits.Nodes[0].Commit.OID
-	}
-
-	reviews := make([]botReviewNode, 0, len(pr.Reviews.Nodes))
-	for _, review := range pr.Reviews.Nodes {
-		reviews = append(reviews, botReviewNode{
-			ID:        review.ID,
-			Author:    review.Author.Login,
-			State:     review.State,
-			Body:      review.Body,
-			CreatedAt: review.CreatedAt,
-			CommitOID: review.Commit.OID,
-		})
-	}
-
-	localHeadOID := localGitHeadOID()
-	reviewsTruncated := pr.Reviews.PageInfo.HasPreviousPage
-	return buildBotReviewReport(
-		pr.Number,
-		pr.Title,
-		prHeadOID,
-		localHeadOID,
-		reviews,
-		threads,
-		reviewsTruncated,
-		threadsTruncated,
-	), nil
+	return threads, threadsTruncated, nil
 }
 
-func botThreadNodesFromResponse(response botReviewStatusResponse) ([]botThreadNode, bool) {
+func botThreadNodesFromResponse(response botReviewThreadsResponse) ([]botThreadNode, bool) {
 	pr := response.Data.Repository.PullRequest
 	threads := make([]botThreadNode, 0, len(pr.ReviewThreads.Nodes))
 	threadsTruncated := false
@@ -364,8 +455,7 @@ func buildBotReviewReport(
 	localHeadOID string,
 	reviews []botReviewNode,
 	threads []botThreadNode,
-	reviewsTruncated bool,
-	threadsTruncated bool,
+	completeness botStatusCompleteness,
 ) *BotReviewReport {
 	bots := []ReviewBotStatus{
 		buildReviewBotStatus(
@@ -374,8 +464,7 @@ func buildBotReviewReport(
 			prHeadOID,
 			reviews,
 			threads,
-			reviewsTruncated,
-			threadsTruncated,
+			completeness,
 		),
 		buildReviewBotStatus(
 			"gemini",
@@ -383,8 +472,7 @@ func buildBotReviewReport(
 			prHeadOID,
 			reviews,
 			threads,
-			reviewsTruncated,
-			threadsTruncated,
+			completeness,
 		),
 	}
 
@@ -394,8 +482,8 @@ func buildBotReviewReport(
 		PRHeadOID:          prHeadOID,
 		LocalHeadOID:       localHeadOID,
 		LocalHeadMatchesPR: localHeadOID != "" && prHeadOID != "" && localHeadOID == prHeadOID,
-		ReviewsTruncated:   reviewsTruncated,
-		ThreadsTruncated:   threadsTruncated,
+		ReviewsTruncated:   completeness.ReviewsTruncated,
+		ThreadsTruncated:   completeness.ThreadsTruncated,
 		Bots:               bots,
 	}
 }
@@ -406,8 +494,7 @@ func buildReviewBotStatus(
 	headOID string,
 	reviews []botReviewNode,
 	threads []botThreadNode,
-	reviewsTruncated bool,
-	reviewDataIncomplete bool,
+	completeness botStatusCompleteness,
 ) ReviewBotStatus {
 	var latest *botReviewNode
 	var latestCurrentHead *botReviewNode
@@ -432,7 +519,7 @@ func buildReviewBotStatus(
 		ReadinessPolicy:              readinessPolicy(login),
 		UnresolvedCurrentHeadThreads: currentHeadThreads,
 		UnresolvedOtherThreads:       otherThreads,
-		ReviewDataIncomplete:         reviewDataIncomplete || (reviewsTruncated && latestCurrentHead == nil),
+		ReviewDataIncomplete:         completeness.ThreadsTruncated || (completeness.ReviewsTruncated && latestCurrentHead == nil),
 	}
 
 	if latest != nil {
@@ -589,6 +676,13 @@ func requestGeminiReviewForCurrentHead(client *GitHubClient, prNumber string) er
 			fmt.Printf("✅ Gemini already reviewed PR head %s; skipping duplicate request\n", report.PRHeadOID)
 			return nil
 		}
+		if bot.ReviewDataIncomplete {
+			return fmt.Errorf("cannot safely request Gemini review because bot review data is incomplete; inspect bot-status output or request /gemini review manually")
+		}
+	}
+
+	if report.ReviewsTruncated {
+		return fmt.Errorf("cannot safely request Gemini review because review history is incomplete; inspect bot-status output or request /gemini review manually")
 	}
 
 	if report.LocalHeadOID != "" && report.PRHeadOID != "" && !report.LocalHeadMatchesPR {

--- a/gh-helper/bot_status.go
+++ b/gh-helper/bot_status.go
@@ -1,0 +1,496 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	copilotReviewBotLogin = "copilot-pull-request-reviewer[bot]"
+	geminiReviewBotLogin  = "gemini-code-assist[bot]"
+)
+
+var botStatusCmd = &cobra.Command{
+	Use:   "bot-status [pr-number]",
+	Short: "Show Copilot and Gemini review status for the current PR head",
+	Long: `Show whether Copilot and Gemini have reviewed the current PR head.
+
+This command is designed for review-loop automation. It reports the PR head
+commit, the local HEAD commit when available, each bot's latest current-head
+review, and unresolved current-head threads authored by that bot.
+
+` + prNumberArgsHelp + `
+
+Examples:
+  gh-helper reviews bot-status 306
+  gh-helper reviews bot-status        # Auto-detect current branch PR
+  gh-helper reviews bot-status 306 --json`,
+	Args:         cobra.MaximumNArgs(1),
+	SilenceUsage: true,
+	RunE:         showBotStatus,
+}
+
+type BotReviewReport struct {
+	PR                 int               `json:"pr"`
+	Title              string            `json:"title"`
+	PRHeadOID          string            `json:"prHeadOid"`
+	LocalHeadOID       string            `json:"localHeadOid,omitempty"`
+	LocalHeadMatchesPR bool              `json:"localHeadMatchesPr"`
+	ThreadsTruncated   bool              `json:"threadsTruncated"`
+	Bots               []ReviewBotStatus `json:"bots"`
+}
+
+type ReviewBotStatus struct {
+	Bot                          string             `json:"bot"`
+	Login                        string             `json:"login"`
+	ReviewedCurrentHead          bool               `json:"reviewedCurrentHead"`
+	Ready                        bool               `json:"ready"`
+	PositiveSignal               string             `json:"positiveSignal,omitempty"`
+	LatestReviewID               string             `json:"latestReviewId,omitempty"`
+	LatestReviewState            string             `json:"latestReviewState,omitempty"`
+	LatestReviewCommitOID        string             `json:"latestReviewCommitOid,omitempty"`
+	LatestReviewCreatedAt        string             `json:"latestReviewCreatedAt,omitempty"`
+	LatestCurrentHeadReviewID    string             `json:"latestCurrentHeadReviewId,omitempty"`
+	LatestCurrentHeadReviewState string             `json:"latestCurrentHeadReviewState,omitempty"`
+	UnresolvedCurrentHeadThreads []BotThreadSummary `json:"unresolvedCurrentHeadThreads"`
+	NextAction                   string             `json:"nextAction"`
+}
+
+type BotThreadSummary struct {
+	ID          string `json:"id"`
+	Path        string `json:"path"`
+	Line        *int   `json:"line"`
+	IsOutdated  bool   `json:"isOutdated"`
+	Author      string `json:"author"`
+	CreatedAt   string `json:"createdAt"`
+	BodyPreview string `json:"bodyPreview"`
+}
+
+type botReviewNode struct {
+	ID        string
+	Author    string
+	State     string
+	Body      string
+	CreatedAt string
+	CommitOID string
+}
+
+type botThreadNode struct {
+	ID         string
+	Path       string
+	Line       *int
+	IsResolved bool
+	IsOutdated bool
+	Comments   []botThreadComment
+}
+
+type botThreadComment struct {
+	Author    string
+	Body      string
+	CreatedAt string
+	State     string
+	CommitOID string
+}
+
+func showBotStatus(cmd *cobra.Command, args []string) error {
+	client := NewGitHubClient(owner, repo)
+	prNumber, err := resolvePRNumberFromArgs(args, client)
+	if err != nil {
+		return err
+	}
+
+	report, err := client.GetBotReviewReport(prNumber)
+	if err != nil {
+		return err
+	}
+
+	return EncodeOutputWithCmd(cmd, map[string]interface{}{
+		"botStatus": report,
+	})
+}
+
+func (c *GitHubClient) GetBotReviewReport(prNumber string) (*BotReviewReport, error) {
+	prNumberInt, err := strconv.Atoi(prNumber)
+	if err != nil {
+		return nil, fmt.Errorf("invalid PR number format: %w", err)
+	}
+
+	query := `
+query($owner: String!, $repo: String!, $prNumber: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $prNumber) {
+      number
+      title
+      commits(last: 1) {
+        nodes {
+          commit {
+            oid
+          }
+        }
+      }
+      reviews(last: 100) {
+        nodes {
+          id
+          author { login }
+          state
+          body
+          createdAt
+          commit {
+            oid
+          }
+        }
+      }
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          path
+          line
+          isResolved
+          isOutdated
+          comments(first: 100) {
+            nodes {
+              body
+              createdAt
+              state
+              author { login }
+              pullRequestReview {
+                commit {
+                  oid
+                }
+              }
+            }
+          }
+        }
+        pageInfo {
+          hasNextPage
+        }
+      }
+    }
+  }
+}`
+
+	variables := map[string]interface{}{
+		"owner":    c.Owner,
+		"repo":     c.Repo,
+		"prNumber": prNumberInt,
+	}
+
+	result, err := c.RunGraphQLQueryWithVariables(query, variables)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch bot review status: %w", err)
+	}
+
+	var response struct {
+		Data struct {
+			Repository struct {
+				PullRequest struct {
+					Number  int    `json:"number"`
+					Title   string `json:"title"`
+					Commits struct {
+						Nodes []struct {
+							Commit struct {
+								OID string `json:"oid"`
+							} `json:"commit"`
+						} `json:"nodes"`
+					} `json:"commits"`
+					Reviews struct {
+						Nodes []struct {
+							ID     string `json:"id"`
+							Author struct {
+								Login string `json:"login"`
+							} `json:"author"`
+							State     string `json:"state"`
+							Body      string `json:"body"`
+							CreatedAt string `json:"createdAt"`
+							Commit    struct {
+								OID string `json:"oid"`
+							} `json:"commit"`
+						} `json:"nodes"`
+					} `json:"reviews"`
+					ReviewThreads struct {
+						PageInfo struct {
+							HasNextPage bool `json:"hasNextPage"`
+						} `json:"pageInfo"`
+						Nodes []struct {
+							ID         string `json:"id"`
+							Path       string `json:"path"`
+							Line       *int   `json:"line"`
+							IsResolved bool   `json:"isResolved"`
+							IsOutdated bool   `json:"isOutdated"`
+							Comments   struct {
+								Nodes []struct {
+									Body      string `json:"body"`
+									CreatedAt string `json:"createdAt"`
+									State     string `json:"state"`
+									Author    struct {
+										Login string `json:"login"`
+									} `json:"author"`
+									PullRequestReview struct {
+										Commit struct {
+											OID string `json:"oid"`
+										} `json:"commit"`
+									} `json:"pullRequestReview"`
+								} `json:"nodes"`
+							} `json:"comments"`
+						} `json:"nodes"`
+					} `json:"reviewThreads"`
+				} `json:"pullRequest"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+
+	if err := Unmarshal(result, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse bot review status: %w", err)
+	}
+
+	pr := response.Data.Repository.PullRequest
+	prHeadOID := ""
+	if len(pr.Commits.Nodes) > 0 {
+		prHeadOID = pr.Commits.Nodes[0].Commit.OID
+	}
+
+	reviews := make([]botReviewNode, 0, len(pr.Reviews.Nodes))
+	for _, review := range pr.Reviews.Nodes {
+		reviews = append(reviews, botReviewNode{
+			ID:        review.ID,
+			Author:    review.Author.Login,
+			State:     review.State,
+			Body:      review.Body,
+			CreatedAt: review.CreatedAt,
+			CommitOID: review.Commit.OID,
+		})
+	}
+
+	threads := make([]botThreadNode, 0, len(pr.ReviewThreads.Nodes))
+	for _, thread := range pr.ReviewThreads.Nodes {
+		comments := make([]botThreadComment, 0, len(thread.Comments.Nodes))
+		for _, comment := range thread.Comments.Nodes {
+			comments = append(comments, botThreadComment{
+				Author:    comment.Author.Login,
+				Body:      comment.Body,
+				CreatedAt: comment.CreatedAt,
+				State:     comment.State,
+				CommitOID: comment.PullRequestReview.Commit.OID,
+			})
+		}
+		threads = append(threads, botThreadNode{
+			ID:         thread.ID,
+			Path:       thread.Path,
+			Line:       thread.Line,
+			IsResolved: thread.IsResolved,
+			IsOutdated: thread.IsOutdated,
+			Comments:   comments,
+		})
+	}
+
+	localHeadOID := localGitHeadOID()
+	report := buildBotReviewReport(pr.Number, pr.Title, prHeadOID, localHeadOID, reviews, threads)
+	report.ThreadsTruncated = pr.ReviewThreads.PageInfo.HasNextPage
+	return report, nil
+}
+
+func buildBotReviewReport(
+	prNumber int,
+	title string,
+	prHeadOID string,
+	localHeadOID string,
+	reviews []botReviewNode,
+	threads []botThreadNode,
+) *BotReviewReport {
+	bots := []ReviewBotStatus{
+		buildReviewBotStatus("copilot", copilotReviewBotLogin, prHeadOID, reviews, threads),
+		buildReviewBotStatus("gemini", geminiReviewBotLogin, prHeadOID, reviews, threads),
+	}
+
+	return &BotReviewReport{
+		PR:                 prNumber,
+		Title:              title,
+		PRHeadOID:          prHeadOID,
+		LocalHeadOID:       localHeadOID,
+		LocalHeadMatchesPR: localHeadOID != "" && prHeadOID != "" && localHeadOID == prHeadOID,
+		Bots:               bots,
+	}
+}
+
+func buildReviewBotStatus(
+	bot string,
+	login string,
+	headOID string,
+	reviews []botReviewNode,
+	threads []botThreadNode,
+) ReviewBotStatus {
+	var latest *botReviewNode
+	var latestCurrentHead *botReviewNode
+	for i := range reviews {
+		review := &reviews[i]
+		if review.Author != login || !isRelevantBotReview(login, review.Body) {
+			continue
+		}
+		if latest == nil || review.CreatedAt > latest.CreatedAt {
+			latest = review
+		}
+		if review.CommitOID == headOID && (latestCurrentHead == nil || review.CreatedAt > latestCurrentHead.CreatedAt) {
+			latestCurrentHead = review
+		}
+	}
+
+	unresolvedThreads := unresolvedBotThreads(login, headOID, threads)
+	status := ReviewBotStatus{
+		Bot:                          bot,
+		Login:                        login,
+		ReviewedCurrentHead:          latestCurrentHead != nil,
+		UnresolvedCurrentHeadThreads: unresolvedThreads,
+	}
+
+	if latest != nil {
+		status.LatestReviewID = latest.ID
+		status.LatestReviewState = latest.State
+		status.LatestReviewCommitOID = latest.CommitOID
+		status.LatestReviewCreatedAt = latest.CreatedAt
+	}
+	if latestCurrentHead != nil {
+		status.LatestCurrentHeadReviewID = latestCurrentHead.ID
+		status.LatestCurrentHeadReviewState = latestCurrentHead.State
+		status.PositiveSignal = positiveBotReviewSignal(login, latestCurrentHead.Body)
+	}
+
+	status.Ready = botReady(login, status.ReviewedCurrentHead, status.PositiveSignal, unresolvedThreads)
+	status.NextAction = botNextAction(bot, status)
+	return status
+}
+
+func botReady(login string, reviewedCurrentHead bool, positiveSignal string, unresolvedThreads []BotThreadSummary) bool {
+	if !reviewedCurrentHead || len(unresolvedThreads) > 0 {
+		return false
+	}
+	if login == geminiReviewBotLogin {
+		return positiveSignal != ""
+	}
+	return positiveSignal != "" || len(unresolvedThreads) == 0
+}
+
+func unresolvedBotThreads(login string, headOID string, threads []botThreadNode) []BotThreadSummary {
+	summaries := []BotThreadSummary{}
+	for _, thread := range threads {
+		if thread.IsResolved {
+			continue
+		}
+
+		var botComment *botThreadComment
+		for i := range thread.Comments {
+			comment := &thread.Comments[i]
+			if comment.Author == login && comment.CommitOID == headOID {
+				botComment = comment
+			}
+		}
+		if botComment == nil {
+			continue
+		}
+
+		summaries = append(summaries, BotThreadSummary{
+			ID:          thread.ID,
+			Path:        thread.Path,
+			Line:        thread.Line,
+			IsOutdated:  thread.IsOutdated,
+			Author:      botComment.Author,
+			CreatedAt:   botComment.CreatedAt,
+			BodyPreview: truncateForStatus(botComment.Body, 160),
+		})
+	}
+	return summaries
+}
+
+func isRelevantBotReview(login string, body string) bool {
+	if login != geminiReviewBotLogin {
+		return true
+	}
+	if strings.Contains(body, geminiReviewHeader) {
+		return true
+	}
+	return strings.Contains(body, "I have no feedback to provide.")
+}
+
+func positiveBotReviewSignal(login string, body string) string {
+	switch login {
+	case copilotReviewBotLogin:
+		lowerBody := strings.ToLower(body)
+		if strings.Contains(lowerBody, "generated no new comments") {
+			return "generated no new comments"
+		}
+	case geminiReviewBotLogin:
+		if strings.Contains(body, "I have no feedback to provide.") {
+			return "I have no feedback to provide."
+		}
+	}
+	return ""
+}
+
+func botNextAction(bot string, status ReviewBotStatus) string {
+	if len(status.UnresolvedCurrentHeadThreads) > 0 {
+		return "address, reply to, and resolve the unresolved current-head threads"
+	}
+	if status.Ready {
+		return "no action needed for the current PR head"
+	}
+	if status.ReviewedCurrentHead {
+		return "inspect the review body before deciding whether to request another review"
+	}
+	if bot == "gemini" {
+		return "request Gemini review for the current PR head"
+	}
+	return "request Copilot review for the current PR head"
+}
+
+func requestGeminiReviewForCurrentHead(client *GitHubClient, prNumber string) error {
+	report, err := client.GetBotReviewReport(prNumber)
+	if err != nil {
+		return err
+	}
+
+	for _, bot := range report.Bots {
+		if bot.Login != geminiReviewBotLogin {
+			continue
+		}
+		if bot.ReviewedCurrentHead {
+			fmt.Printf("✅ Gemini already reviewed PR head %s; skipping duplicate request\n", report.PRHeadOID)
+			return nil
+		}
+	}
+
+	if report.LocalHeadOID != "" && report.PRHeadOID != "" && !report.LocalHeadMatchesPR {
+		fmt.Printf(
+			"⚠️  Local HEAD %s differs from PR head %s; requesting review for the pushed PR head\n",
+			report.LocalHeadOID,
+			report.PRHeadOID,
+		)
+	}
+
+	fmt.Printf("📝 Requesting Gemini review for PR #%s...\n", prNumber)
+	if err := client.CreatePRComment(prNumber, "/gemini review"); err != nil {
+		return fmt.Errorf("failed to request Gemini review: %w", err)
+	}
+	fmt.Println("✅ Gemini review requested")
+	return nil
+}
+
+func localGitHeadOID() string {
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func truncateForStatus(body string, maxLen int) string {
+	body = strings.TrimSpace(body)
+	body = strings.Join(strings.Fields(body), " ")
+	if len(body) <= maxLen {
+		return body
+	}
+	return body[:maxLen] + "..."
+}

--- a/gh-helper/bot_status.go
+++ b/gh-helper/bot_status.go
@@ -4,7 +4,8 @@ import (
 	_ "embed"
 	"fmt"
 	"log/slog"
-	"os/exec"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -670,18 +671,127 @@ func geminiReviewedCurrentHead(metadata *botReviewMetadata) bool {
 }
 
 func localGitHeadOID() string {
-	gitPath, err := exec.LookPath("git")
+	dir, err := os.Getwd()
 	if err != nil {
-		slog.Debug("git command not found, cannot get local HEAD OID", "error", err)
+		slog.Debug("failed to get working directory, cannot get local HEAD OID", "error", err)
 		return ""
 	}
-	cmd := exec.Command(gitPath, "rev-parse", "HEAD")
-	output, err := cmd.Output()
+	for {
+		gitDir, err := resolveGitDir(filepath.Join(dir, ".git"))
+		if err == nil {
+			return readGitHeadOID(gitDir)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			slog.Debug("git directory not found, cannot get local HEAD OID", "error", err)
+			return ""
+		}
+		dir = parent
+	}
+}
+
+func resolveGitDir(dotGitPath string) (string, error) {
+	info, err := os.Stat(dotGitPath)
 	if err != nil {
-		slog.Debug("failed to get local HEAD OID", "error", err)
+		return "", err
+	}
+	if info.IsDir() {
+		return dotGitPath, nil
+	}
+
+	data, err := os.ReadFile(dotGitPath)
+	if err != nil {
+		return "", err
+	}
+	gitDir, ok := strings.CutPrefix(strings.TrimSpace(string(data)), "gitdir:")
+	if !ok {
+		return "", fmt.Errorf("%s is not a gitdir file", dotGitPath)
+	}
+	gitDir = strings.TrimSpace(gitDir)
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(filepath.Dir(dotGitPath), gitDir)
+	}
+	return filepath.Clean(gitDir), nil
+}
+
+func readGitHeadOID(gitDir string) string {
+	headData, err := os.ReadFile(filepath.Join(gitDir, "HEAD"))
+	if err != nil {
+		slog.Debug("failed to read git HEAD", "gitDir", gitDir, "error", err)
 		return ""
 	}
-	return strings.TrimSpace(string(output))
+	head := strings.TrimSpace(string(headData))
+	if isGitOID(head) {
+		return head
+	}
+
+	ref, ok := strings.CutPrefix(head, "ref:")
+	if !ok {
+		slog.Debug("git HEAD has unsupported format", "head", head)
+		return ""
+	}
+	ref = strings.TrimSpace(ref)
+	for _, root := range gitRefRoots(gitDir) {
+		if oid := readGitRef(root, ref); oid != "" {
+			return oid
+		}
+	}
+	slog.Debug("failed to resolve git HEAD ref", "gitDir", gitDir, "ref", ref)
+	return ""
+}
+
+func gitRefRoots(gitDir string) []string {
+	roots := []string{gitDir}
+	commondirData, err := os.ReadFile(filepath.Join(gitDir, "commondir"))
+	if err != nil {
+		return roots
+	}
+	commonDir := strings.TrimSpace(string(commondirData))
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(gitDir, commonDir)
+	}
+	commonDir = filepath.Clean(commonDir)
+	if commonDir != gitDir {
+		roots = append(roots, commonDir)
+	}
+	return roots
+}
+
+func readGitRef(root string, ref string) string {
+	refData, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(ref)))
+	if err == nil {
+		oid := strings.TrimSpace(string(refData))
+		if isGitOID(oid) {
+			return oid
+		}
+	}
+
+	packedRefs, err := os.ReadFile(filepath.Join(root, "packed-refs"))
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(packedRefs), "\n") {
+		if strings.HasPrefix(line, "#") || strings.HasPrefix(line, "^") {
+			continue
+		}
+		oid, packedRef, ok := strings.Cut(strings.TrimSpace(line), " ")
+		if ok && packedRef == ref && isGitOID(oid) {
+			return oid
+		}
+	}
+	return ""
+}
+
+func isGitOID(value string) bool {
+	if len(value) != 40 && len(value) != 64 {
+		return false
+	}
+	for _, r := range value {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') && (r < 'A' || r > 'F') {
+			return false
+		}
+	}
+	return true
 }
 
 func truncateForStatus(body string, maxLen int) string {

--- a/gh-helper/bot_status_test.go
+++ b/gh-helper/bot_status_test.go
@@ -24,7 +24,7 @@ func TestBuildReviewBotStatusGeminiIgnoresSummaryReview(t *testing.T) {
 		},
 	}
 
-	status := buildReviewBotStatus("gemini", geminiReviewBotLogin, "head", reviews, nil)
+	status := buildReviewBotStatus("gemini", geminiReviewBotLogin, "head", reviews, nil, false)
 	if !status.ReviewedCurrentHead {
 		t.Fatal("Gemini code review was not recognized for current head")
 	}
@@ -50,7 +50,7 @@ func TestBuildReviewBotStatusGeminiRequiresPositiveSignal(t *testing.T) {
 		},
 	}
 
-	status := buildReviewBotStatus("gemini", geminiReviewBotLogin, "head", reviews, nil)
+	status := buildReviewBotStatus("gemini", geminiReviewBotLogin, "head", reviews, nil, false)
 	if !status.ReviewedCurrentHead {
 		t.Fatal("Gemini review was not recognized for current head")
 	}
@@ -106,9 +106,12 @@ func TestBuildReviewBotStatusCurrentHeadThreads(t *testing.T) {
 		},
 	}
 
-	status := buildReviewBotStatus("copilot", copilotReviewBotLogin, "head", nil, threads)
+	status := buildReviewBotStatus("copilot", copilotReviewBotLogin, "head", nil, threads, false)
 	if len(status.UnresolvedCurrentHeadThreads) != 1 {
 		t.Fatalf("UnresolvedCurrentHeadThreads len = %d, want 1", len(status.UnresolvedCurrentHeadThreads))
+	}
+	if len(status.UnresolvedOtherThreads) != 1 {
+		t.Fatalf("UnresolvedOtherThreads len = %d, want 1", len(status.UnresolvedOtherThreads))
 	}
 	if status.UnresolvedCurrentHeadThreads[0].ID != "current-thread" {
 		t.Fatalf("Thread ID = %q, want current-thread", status.UnresolvedCurrentHeadThreads[0].ID)
@@ -121,13 +124,59 @@ func TestBuildReviewBotStatusCurrentHeadThreads(t *testing.T) {
 func TestBuildBotReviewReportLocalHeadMatch(t *testing.T) {
 	t.Parallel()
 
-	report := buildBotReviewReport(12, "test", "abc", "abc", nil, nil)
+	report := buildBotReviewReport(12, "test", "abc", "abc", nil, nil, false)
 	if !report.LocalHeadMatchesPR {
 		t.Fatal("LocalHeadMatchesPR = false, want true")
 	}
 
-	report = buildBotReviewReport(12, "test", "abc", "def", nil, nil)
+	report = buildBotReviewReport(12, "test", "abc", "def", nil, nil, false)
 	if report.LocalHeadMatchesPR {
 		t.Fatal("LocalHeadMatchesPR = true, want false")
+	}
+}
+
+func TestBuildReviewBotStatusNormalizesBotLogin(t *testing.T) {
+	t.Parallel()
+
+	reviews := []botReviewNode{
+		{
+			ID:        "copilot-review",
+			Author:    copilotReviewBotLogin + "[bot]",
+			State:     "COMMENTED",
+			Body:      "Copilot generated no new comments.",
+			CreatedAt: "2026-05-03T01:00:00Z",
+			CommitOID: "head",
+		},
+	}
+
+	status := buildReviewBotStatus("copilot", copilotReviewBotLogin, "head", reviews, nil, false)
+	if !status.ReviewedCurrentHead {
+		t.Fatal("Copilot review with [bot] suffix was not recognized")
+	}
+	if !status.Ready {
+		t.Fatal("Copilot review with no unresolved threads should be ready")
+	}
+}
+
+func TestBuildReviewBotStatusIncompleteDataIsNotReady(t *testing.T) {
+	t.Parallel()
+
+	reviews := []botReviewNode{
+		{
+			ID:        "copilot-review",
+			Author:    copilotReviewBotLogin,
+			State:     "COMMENTED",
+			Body:      "Copilot generated no new comments.",
+			CreatedAt: "2026-05-03T01:00:00Z",
+			CommitOID: "head",
+		},
+	}
+
+	status := buildReviewBotStatus("copilot", copilotReviewBotLogin, "head", reviews, nil, true)
+	if status.Ready {
+		t.Fatal("Incomplete review data should not be ready")
+	}
+	if !status.ReviewDataIncomplete {
+		t.Fatal("ReviewDataIncomplete = false, want true")
 	}
 }

--- a/gh-helper/bot_status_test.go
+++ b/gh-helper/bot_status_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -291,6 +292,24 @@ func TestReadGitHeadOIDFromPackedRef(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(gitDir, "packed-refs"), []byte(oid+" refs/heads/main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := readGitHeadOID(gitDir); got != oid {
+		t.Fatalf("readGitHeadOID() = %q, want %q", got, oid)
+	}
+}
+
+func TestReadGitHeadOIDFromLongPackedRef(t *testing.T) {
+	t.Parallel()
+
+	gitDir := t.TempDir()
+	const oid = "0123456789abcdef0123456789abcdef01234567"
+	ref := "refs/heads/" + strings.Repeat("long-ref-name/", 5000) + "main"
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: "+ref+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "packed-refs"), []byte(oid+" "+ref+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/gh-helper/bot_status_test.go
+++ b/gh-helper/bot_status_test.go
@@ -24,7 +24,7 @@ func TestBuildReviewBotStatusGeminiIgnoresSummaryReview(t *testing.T) {
 		},
 	}
 
-	status := buildReviewBotStatus("gemini", geminiReviewBotLogin, "head", reviews, nil, false)
+	status := buildReviewBotStatus("gemini", geminiReviewBotLogin, "head", reviews, nil, false, false)
 	if !status.ReviewedCurrentHead {
 		t.Fatal("Gemini code review was not recognized for current head")
 	}
@@ -50,12 +50,15 @@ func TestBuildReviewBotStatusGeminiRequiresPositiveSignal(t *testing.T) {
 		},
 	}
 
-	status := buildReviewBotStatus("gemini", geminiReviewBotLogin, "head", reviews, nil, false)
+	status := buildReviewBotStatus("gemini", geminiReviewBotLogin, "head", reviews, nil, false, false)
 	if !status.ReviewedCurrentHead {
 		t.Fatal("Gemini review was not recognized for current head")
 	}
 	if status.Ready {
 		t.Fatal("Gemini review without the no-feedback signal should not be ready")
+	}
+	if status.ReadinessPolicy == "" {
+		t.Fatal("ReadinessPolicy is empty")
 	}
 }
 
@@ -106,7 +109,7 @@ func TestBuildReviewBotStatusCurrentHeadThreads(t *testing.T) {
 		},
 	}
 
-	status := buildReviewBotStatus("copilot", copilotReviewBotLogin, "head", nil, threads, false)
+	status := buildReviewBotStatus("copilot", copilotReviewBotLogin, "head", nil, threads, false, false)
 	if len(status.UnresolvedCurrentHeadThreads) != 1 {
 		t.Fatalf("UnresolvedCurrentHeadThreads len = %d, want 1", len(status.UnresolvedCurrentHeadThreads))
 	}
@@ -124,12 +127,12 @@ func TestBuildReviewBotStatusCurrentHeadThreads(t *testing.T) {
 func TestBuildBotReviewReportLocalHeadMatch(t *testing.T) {
 	t.Parallel()
 
-	report := buildBotReviewReport(12, "test", "abc", "abc", nil, nil, false)
+	report := buildBotReviewReport(12, "test", "abc", "abc", nil, nil, false, false)
 	if !report.LocalHeadMatchesPR {
 		t.Fatal("LocalHeadMatchesPR = false, want true")
 	}
 
-	report = buildBotReviewReport(12, "test", "abc", "def", nil, nil, false)
+	report = buildBotReviewReport(12, "test", "abc", "def", nil, nil, false, false)
 	if report.LocalHeadMatchesPR {
 		t.Fatal("LocalHeadMatchesPR = true, want false")
 	}
@@ -149,7 +152,7 @@ func TestBuildReviewBotStatusNormalizesBotLogin(t *testing.T) {
 		},
 	}
 
-	status := buildReviewBotStatus("copilot", copilotReviewBotLogin, "head", reviews, nil, false)
+	status := buildReviewBotStatus("copilot", copilotReviewBotLogin, "head", reviews, nil, false, false)
 	if !status.ReviewedCurrentHead {
 		t.Fatal("Copilot review with [bot] suffix was not recognized")
 	}
@@ -172,9 +175,21 @@ func TestBuildReviewBotStatusIncompleteDataIsNotReady(t *testing.T) {
 		},
 	}
 
-	status := buildReviewBotStatus("copilot", copilotReviewBotLogin, "head", reviews, nil, true)
+	status := buildReviewBotStatus("copilot", copilotReviewBotLogin, "head", reviews, nil, false, true)
 	if status.Ready {
 		t.Fatal("Incomplete review data should not be ready")
+	}
+	if !status.ReviewDataIncomplete {
+		t.Fatal("ReviewDataIncomplete = false, want true")
+	}
+}
+
+func TestBuildReviewBotStatusTruncatedReviewsWithoutCurrentHeadIsIncomplete(t *testing.T) {
+	t.Parallel()
+
+	status := buildReviewBotStatus("copilot", copilotReviewBotLogin, "head", nil, nil, true, false)
+	if status.Ready {
+		t.Fatal("Truncated reviews without a current-head review should not be ready")
 	}
 	if !status.ReviewDataIncomplete {
 		t.Fatal("ReviewDataIncomplete = false, want true")

--- a/gh-helper/bot_status_test.go
+++ b/gh-helper/bot_status_test.go
@@ -1,0 +1,133 @@
+package main
+
+import "testing"
+
+func TestBuildReviewBotStatusGeminiIgnoresSummaryReview(t *testing.T) {
+	t.Parallel()
+
+	reviews := []botReviewNode{
+		{
+			ID:        "summary",
+			Author:    geminiReviewBotLogin,
+			State:     "COMMENTED",
+			Body:      geminiSummaryHeader + "\n\nSummary only.",
+			CreatedAt: "2026-05-03T01:00:00Z",
+			CommitOID: "head",
+		},
+		{
+			ID:        "code-review",
+			Author:    geminiReviewBotLogin,
+			State:     "COMMENTED",
+			Body:      "I have no feedback to provide.",
+			CreatedAt: "2026-05-03T00:59:00Z",
+			CommitOID: "head",
+		},
+	}
+
+	status := buildReviewBotStatus("gemini", geminiReviewBotLogin, "head", reviews, nil)
+	if !status.ReviewedCurrentHead {
+		t.Fatal("Gemini code review was not recognized for current head")
+	}
+	if !status.Ready {
+		t.Fatal("Gemini positive review should be ready")
+	}
+	if status.LatestCurrentHeadReviewID != "code-review" {
+		t.Fatalf("LatestCurrentHeadReviewID = %q, want code-review", status.LatestCurrentHeadReviewID)
+	}
+}
+
+func TestBuildReviewBotStatusGeminiRequiresPositiveSignal(t *testing.T) {
+	t.Parallel()
+
+	reviews := []botReviewNode{
+		{
+			ID:        "needs-inspection",
+			Author:    geminiReviewBotLogin,
+			State:     "COMMENTED",
+			Body:      geminiReviewHeader + "\n\nPlease inspect this.",
+			CreatedAt: "2026-05-03T01:00:00Z",
+			CommitOID: "head",
+		},
+	}
+
+	status := buildReviewBotStatus("gemini", geminiReviewBotLogin, "head", reviews, nil)
+	if !status.ReviewedCurrentHead {
+		t.Fatal("Gemini review was not recognized for current head")
+	}
+	if status.Ready {
+		t.Fatal("Gemini review without the no-feedback signal should not be ready")
+	}
+}
+
+func TestBuildReviewBotStatusCurrentHeadThreads(t *testing.T) {
+	t.Parallel()
+
+	line := 42
+	threads := []botThreadNode{
+		{
+			ID:         "current-thread",
+			Path:       "main.go",
+			Line:       &line,
+			IsResolved: false,
+			Comments: []botThreadComment{
+				{
+					Author:    copilotReviewBotLogin,
+					Body:      "Please fix this current-head issue.",
+					CreatedAt: "2026-05-03T01:00:00Z",
+					CommitOID: "head",
+				},
+			},
+		},
+		{
+			ID:         "old-thread",
+			Path:       "old.go",
+			IsResolved: false,
+			Comments: []botThreadComment{
+				{
+					Author:    copilotReviewBotLogin,
+					Body:      "Old feedback.",
+					CreatedAt: "2026-05-02T01:00:00Z",
+					CommitOID: "old",
+				},
+			},
+		},
+		{
+			ID:         "resolved-thread",
+			Path:       "resolved.go",
+			IsResolved: true,
+			Comments: []botThreadComment{
+				{
+					Author:    copilotReviewBotLogin,
+					Body:      "Resolved feedback.",
+					CreatedAt: "2026-05-03T02:00:00Z",
+					CommitOID: "head",
+				},
+			},
+		},
+	}
+
+	status := buildReviewBotStatus("copilot", copilotReviewBotLogin, "head", nil, threads)
+	if len(status.UnresolvedCurrentHeadThreads) != 1 {
+		t.Fatalf("UnresolvedCurrentHeadThreads len = %d, want 1", len(status.UnresolvedCurrentHeadThreads))
+	}
+	if status.UnresolvedCurrentHeadThreads[0].ID != "current-thread" {
+		t.Fatalf("Thread ID = %q, want current-thread", status.UnresolvedCurrentHeadThreads[0].ID)
+	}
+	if status.NextAction != "address, reply to, and resolve the unresolved current-head threads" {
+		t.Fatalf("NextAction = %q, want address guidance", status.NextAction)
+	}
+}
+
+func TestBuildBotReviewReportLocalHeadMatch(t *testing.T) {
+	t.Parallel()
+
+	report := buildBotReviewReport(12, "test", "abc", "abc", nil, nil)
+	if !report.LocalHeadMatchesPR {
+		t.Fatal("LocalHeadMatchesPR = false, want true")
+	}
+
+	report = buildBotReviewReport(12, "test", "abc", "def", nil, nil)
+	if report.LocalHeadMatchesPR {
+		t.Fatal("LocalHeadMatchesPR = true, want false")
+	}
+}

--- a/gh-helper/bot_status_test.go
+++ b/gh-helper/bot_status_test.go
@@ -128,6 +128,66 @@ func TestBuildReviewBotStatusCurrentHeadThreads(t *testing.T) {
 	}
 }
 
+func TestBuildReviewBotStatusUsesFirstThreadCommentForBotAttribution(t *testing.T) {
+	t.Parallel()
+
+	threads := []botThreadNode{
+		{
+			ID:         "human-thread-with-bot-reply",
+			Path:       "human.go",
+			IsResolved: false,
+			Comments: []botThreadComment{
+				{
+					Author:    "apstndb",
+					Body:      "Human feedback.",
+					CreatedAt: "2026-05-03T01:00:00Z",
+					CommitOID: "head",
+				},
+				{
+					Author:    copilotReviewBotLogin,
+					Body:      "Bot follow-up should not own this thread.",
+					CreatedAt: "2026-05-03T01:01:00Z",
+					CommitOID: "head",
+				},
+			},
+		},
+		{
+			ID:         "bot-thread-with-human-reply",
+			Path:       "bot.go",
+			IsResolved: false,
+			Comments: []botThreadComment{
+				{
+					Author:    copilotReviewBotLogin,
+					Body:      "Bot feedback.",
+					CreatedAt: "2026-05-03T02:00:00Z",
+					CommitOID: "head",
+				},
+				{
+					Author:    "apstndb",
+					Body:      "Human reply should not replace the thread origin.",
+					CreatedAt: "2026-05-03T02:01:00Z",
+					CommitOID: "head",
+				},
+			},
+		},
+	}
+
+	status := buildReviewBotStatus("copilot", copilotReviewBotLogin, "head", nil, threads, botStatusCompleteness{})
+	if len(status.UnresolvedCurrentHeadThreads) != 1 {
+		t.Fatalf("UnresolvedCurrentHeadThreads len = %d, want 1", len(status.UnresolvedCurrentHeadThreads))
+	}
+	thread := status.UnresolvedCurrentHeadThreads[0]
+	if thread.ID != "bot-thread-with-human-reply" {
+		t.Fatalf("Thread ID = %q, want bot-thread-with-human-reply", thread.ID)
+	}
+	if thread.Author != copilotReviewBotLogin {
+		t.Fatalf("Thread author = %q, want %q", thread.Author, copilotReviewBotLogin)
+	}
+	if thread.BodyPreview != "Bot feedback." {
+		t.Fatalf("BodyPreview = %q, want first bot comment body", thread.BodyPreview)
+	}
+}
+
 func TestBuildBotReviewReportLocalHeadMatch(t *testing.T) {
 	t.Parallel()
 

--- a/gh-helper/bot_status_test.go
+++ b/gh-helper/bot_status_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestBuildReviewBotStatusGeminiIgnoresSummaryReview(t *testing.T) {
 	t.Parallel()
@@ -193,5 +197,44 @@ func TestBuildReviewBotStatusTruncatedReviewsWithoutCurrentHeadIsIncomplete(t *t
 	}
 	if !status.ReviewDataIncomplete {
 		t.Fatal("ReviewDataIncomplete = false, want true")
+	}
+}
+
+func TestResolveGitDirFromFile(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	gitDir := filepath.Join(root, "actual.git")
+	if err := os.Mkdir(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dotGit := filepath.Join(root, ".git")
+	if err := os.WriteFile(dotGit, []byte("gitdir: actual.git\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveGitDir(dotGit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != gitDir {
+		t.Fatalf("resolveGitDir() = %q, want %q", got, gitDir)
+	}
+}
+
+func TestReadGitHeadOIDFromPackedRef(t *testing.T) {
+	t.Parallel()
+
+	gitDir := t.TempDir()
+	const oid = "0123456789abcdef0123456789abcdef01234567"
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "packed-refs"), []byte(oid+" refs/heads/main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := readGitHeadOID(gitDir); got != oid {
+		t.Fatalf("readGitHeadOID() = %q, want %q", got, oid)
 	}
 }

--- a/gh-helper/bot_status_test.go
+++ b/gh-helper/bot_status_test.go
@@ -24,7 +24,7 @@ func TestBuildReviewBotStatusGeminiIgnoresSummaryReview(t *testing.T) {
 		},
 	}
 
-	status := buildReviewBotStatus("gemini", geminiReviewBotLogin, "head", reviews, nil, false, false)
+	status := buildReviewBotStatus("gemini", geminiReviewBotLogin, "head", reviews, nil, botStatusCompleteness{})
 	if !status.ReviewedCurrentHead {
 		t.Fatal("Gemini code review was not recognized for current head")
 	}
@@ -50,7 +50,7 @@ func TestBuildReviewBotStatusGeminiRequiresPositiveSignal(t *testing.T) {
 		},
 	}
 
-	status := buildReviewBotStatus("gemini", geminiReviewBotLogin, "head", reviews, nil, false, false)
+	status := buildReviewBotStatus("gemini", geminiReviewBotLogin, "head", reviews, nil, botStatusCompleteness{})
 	if !status.ReviewedCurrentHead {
 		t.Fatal("Gemini review was not recognized for current head")
 	}
@@ -109,7 +109,7 @@ func TestBuildReviewBotStatusCurrentHeadThreads(t *testing.T) {
 		},
 	}
 
-	status := buildReviewBotStatus("copilot", copilotReviewBotLogin, "head", nil, threads, false, false)
+	status := buildReviewBotStatus("copilot", copilotReviewBotLogin, "head", nil, threads, botStatusCompleteness{})
 	if len(status.UnresolvedCurrentHeadThreads) != 1 {
 		t.Fatalf("UnresolvedCurrentHeadThreads len = %d, want 1", len(status.UnresolvedCurrentHeadThreads))
 	}
@@ -127,12 +127,12 @@ func TestBuildReviewBotStatusCurrentHeadThreads(t *testing.T) {
 func TestBuildBotReviewReportLocalHeadMatch(t *testing.T) {
 	t.Parallel()
 
-	report := buildBotReviewReport(12, "test", "abc", "abc", nil, nil, false, false)
+	report := buildBotReviewReport(12, "test", "abc", "abc", nil, nil, botStatusCompleteness{})
 	if !report.LocalHeadMatchesPR {
 		t.Fatal("LocalHeadMatchesPR = false, want true")
 	}
 
-	report = buildBotReviewReport(12, "test", "abc", "def", nil, nil, false, false)
+	report = buildBotReviewReport(12, "test", "abc", "def", nil, nil, botStatusCompleteness{})
 	if report.LocalHeadMatchesPR {
 		t.Fatal("LocalHeadMatchesPR = true, want false")
 	}
@@ -152,7 +152,7 @@ func TestBuildReviewBotStatusNormalizesBotLogin(t *testing.T) {
 		},
 	}
 
-	status := buildReviewBotStatus("copilot", copilotReviewBotLogin, "head", reviews, nil, false, false)
+	status := buildReviewBotStatus("copilot", copilotReviewBotLogin, "head", reviews, nil, botStatusCompleteness{})
 	if !status.ReviewedCurrentHead {
 		t.Fatal("Copilot review with [bot] suffix was not recognized")
 	}
@@ -175,7 +175,7 @@ func TestBuildReviewBotStatusIncompleteDataIsNotReady(t *testing.T) {
 		},
 	}
 
-	status := buildReviewBotStatus("copilot", copilotReviewBotLogin, "head", reviews, nil, false, true)
+	status := buildReviewBotStatus("copilot", copilotReviewBotLogin, "head", reviews, nil, botStatusCompleteness{ThreadsTruncated: true})
 	if status.Ready {
 		t.Fatal("Incomplete review data should not be ready")
 	}
@@ -187,7 +187,7 @@ func TestBuildReviewBotStatusIncompleteDataIsNotReady(t *testing.T) {
 func TestBuildReviewBotStatusTruncatedReviewsWithoutCurrentHeadIsIncomplete(t *testing.T) {
 	t.Parallel()
 
-	status := buildReviewBotStatus("copilot", copilotReviewBotLogin, "head", nil, nil, true, false)
+	status := buildReviewBotStatus("copilot", copilotReviewBotLogin, "head", nil, nil, botStatusCompleteness{ReviewsTruncated: true})
 	if status.Ready {
 		t.Fatal("Truncated reviews without a current-head review should not be ready")
 	}

--- a/gh-helper/github.go
+++ b/gh-helper/github.go
@@ -305,7 +305,7 @@ func (c *GitHubClient) CreatePRConversationCommentREST(prNumber, body string) er
 
 	token, err := getToken()
 	if err != nil {
-		return fmt.Errorf("failed to get GitHub token: %w", err)
+		return fmt.Errorf("REST comment auth failed: %w", err)
 	}
 
 	payload, err := FormatJSON.Marshal(map[string]string{"body": body})

--- a/gh-helper/github.go
+++ b/gh-helper/github.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"sync"
 	"time"
-	
+
 	"golang.org/x/net/http2"
 )
 
@@ -30,7 +30,6 @@ var (
 	sharedHTTPClient *http.Client
 	clientOnce       sync.Once
 )
-
 
 // Repository IDs are immutable for the lifetime of a repository
 // - Renaming a repo preserves the ID
@@ -63,7 +62,7 @@ func getOptimizedHTTPClient() *http.Client {
 	return sharedHTTPClient
 }
 
-// PRInfo represents basic PR information  
+// PRInfo represents basic PR information
 type PRInfo struct {
 	Number int    `json:"number"`
 	Title  string `json:"title"`
@@ -108,7 +107,7 @@ func (c *GitHubClient) ValidateClient() error {
 	return nil
 }
 
-// getToken retrieves GitHub token from gh CLI  
+// getToken retrieves GitHub token from gh CLI
 // No caching needed - auth tokens don't invalidate during single command execution
 func getToken() (string, error) {
 	cmd := exec.Command("gh", "auth", "token")
@@ -214,7 +213,7 @@ func (c *GitHubClient) RunGraphQLQueryWithVariables(query string, variables map[
 }
 
 // CreatePRComment creates a comment on a pull request using GraphQL mutation
-// 
+//
 // NOTE: Attempted single-request optimization, but addComment is a root-level mutation
 // that requires a node ID, not accessible via nested repository context.
 // Keeping the 2-step approach: query PR ID → mutation addComment
@@ -290,6 +289,60 @@ func (c *GitHubClient) CreatePRComment(prNumber, body string) error {
 	return nil
 }
 
+// CreatePRConversationCommentREST creates a top-level PR conversation comment
+// through the REST issue-comments API. GitHub PR conversation comments are issue
+// comments, so this avoids GraphQL budget for simple slash-command triggers.
+func (c *GitHubClient) CreatePRConversationCommentREST(prNumber, body string) error {
+	if err := c.ValidateClient(); err != nil {
+		return err
+	}
+	prNumberInt, err := strconv.Atoi(prNumber)
+	if err != nil {
+		return fmt.Errorf("invalid PR number format: %w", err)
+	}
+
+	token, err := getToken()
+	if err != nil {
+		return fmt.Errorf("failed to get GitHub token: %w", err)
+	}
+
+	payload, err := FormatJSON.Marshal(map[string]string{"body": body})
+	if err != nil {
+		return fmt.Errorf("failed to marshal REST comment request: %w", err)
+	}
+
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/issues/%d/comments", c.Owner, c.Repo, prNumberInt)
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create REST comment request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("User-Agent", "spanner-mycli-dev-tools/1.0")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute REST comment request: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			slog.Warn("failed to close response body", "url", resp.Request.URL.String(), "error", err)
+		}
+	}()
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(resp.Body); err != nil {
+		return fmt.Errorf("failed to read REST comment response body: %w", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("REST comment request failed with status %d: %s", resp.StatusCode, buf.String())
+	}
+
+	return nil
+}
+
 // PRCreateOptions represents options for creating a pull request
 type PRCreateOptions struct {
 	Title string `json:"title"`
@@ -303,7 +356,7 @@ type PRCreateOptions struct {
 //
 // DESIGN RATIONALE: Instance-level vs Global Caching
 // - Typical usage: single repo (apstndb/spanner-mycli) per GitHubClient instance
-// - Simple struct fields avoid sync.Map complexity and type assertions  
+// - Simple struct fields avoid sync.Map complexity and type assertions
 // - Repository IDs are immutable for repo lifetime (no TTL needed)
 // - Follows YAGNI: complex global cache unnecessary for current usage patterns
 func (c *GitHubClient) getRepositoryID() (string, error) {
@@ -311,7 +364,7 @@ func (c *GitHubClient) getRepositoryID() (string, error) {
 	if c.repositoryID != "" {
 		return c.repositoryID, nil
 	}
-	
+
 	// Cache miss - fetch from API
 	repoQuery := `
 	query($owner: String!, $repo: String!) {
@@ -344,7 +397,7 @@ func (c *GitHubClient) getRepositoryID() (string, error) {
 
 	// Cache in instance fields (immutable for repository lifetime)
 	c.repositoryID = repoResponse.Data.Repository.ID
-	
+
 	return c.repositoryID, nil
 }
 
@@ -376,12 +429,12 @@ func (c *GitHubClient) CreatePR(opts PRCreateOptions) (*PRInfo, error) {
 	}`
 
 	mutationVariables := map[string]interface{}{
-		"repositoryId":  repositoryID,
-		"baseRefName":   opts.Base,
-		"headRefName":   opts.Head,
-		"title":         opts.Title,
-		"body":          opts.Body,
-		"draft":         opts.Draft,
+		"repositoryId": repositoryID,
+		"baseRefName":  opts.Base,
+		"headRefName":  opts.Head,
+		"title":        opts.Title,
+		"body":         opts.Body,
+		"draft":        opts.Draft,
 	}
 
 	data, err := c.RunGraphQLQueryWithVariables(mutation, mutationVariables)
@@ -412,12 +465,12 @@ func (c *GitHubClient) GetCurrentUser() (string, error) {
 	    login
 	  }
 	}`
-	
+
 	result, err := c.RunGraphQLQuery(query)
 	if err != nil {
 		return "", fmt.Errorf("failed to get current user: %w", err)
 	}
-	
+
 	var response struct {
 		Data struct {
 			Viewer struct {
@@ -425,11 +478,11 @@ func (c *GitHubClient) GetCurrentUser() (string, error) {
 			} `json:"viewer"`
 		} `json:"data"`
 	}
-	
+
 	if err := Unmarshal(result, &response); err != nil {
 		return "", fmt.Errorf("failed to parse user response: %w", err)
 	}
-	
+
 	return response.Data.Viewer.Login, nil
 }
 
@@ -570,7 +623,7 @@ func (c *GitHubClient) ResolveNumber(number int) (*NodeInfo, error) {
 
 // ParseInputFormat parses various input formats for issues/PRs
 type InputFormat struct {
-	Type   string // "issue", "pr", or "auto" 
+	Type   string // "issue", "pr", or "auto"
 	Number int
 }
 
@@ -594,14 +647,14 @@ func ParseInput(input string) (*InputFormat, error) {
 				return nil, fmt.Errorf("invalid issue number in '%s': %w", input, err)
 			}
 			return &InputFormat{Type: "issue", Number: number}, nil
-			
+
 		case "pull", "pr":
 			number, err := strconv.Atoi(numberStr)
 			if err != nil {
 				return nil, fmt.Errorf("invalid PR number in '%s': %w", input, err)
 			}
 			return &InputFormat{Type: "pr", Number: number}, nil
-			
+
 		default:
 			// Has "/" but unknown prefix - treat as invalid
 			return nil, fmt.Errorf("unknown format '%s': use 'issues/N', 'pull/N', 'pr/N', or plain number", input)
@@ -645,14 +698,14 @@ func (c *GitHubClient) ResolvePRNumber(input string) (int, string, error) {
 		if err != nil {
 			return 0, "", fmt.Errorf("failed to find PRs for explicit issue #%d: %w", format.Number, err)
 		}
-		
+
 		// Look for open PR
 		for _, pr := range prs {
 			if pr.State == "OPEN" {
 				return pr.Number, fmt.Sprintf("Resolved explicit issue #%d to open PR #%d: %s", format.Number, pr.Number, pr.Title), nil
 			}
 		}
-		
+
 		if len(prs) > 0 {
 			return 0, "", fmt.Errorf("explicit issue #%d has %d associated PR(s) but none are open", format.Number, len(prs))
 		}
@@ -674,14 +727,14 @@ func (c *GitHubClient) ResolvePRNumber(input string) (int, string, error) {
 			if err != nil {
 				return 0, "", fmt.Errorf("failed to find PRs for auto-detected issue #%d: %w", node.Number, err)
 			}
-			
+
 			// Look for open PR
 			for _, pr := range prs {
 				if pr.State == "OPEN" {
 					return pr.Number, fmt.Sprintf("Auto-detected issue #%d → open PR #%d: %s", node.Number, pr.Number, pr.Title), nil
 				}
 			}
-			
+
 			if len(prs) > 0 {
 				return 0, "", fmt.Errorf("auto-detected issue #%d has %d associated PR(s) but none are open", node.Number, len(prs))
 			}
@@ -859,7 +912,7 @@ func (c *GitHubClient) SearchItemsByTitle(repoID string, re *regexp.Regexp) ([]I
 	}
 
 	var items []ItemToLabel
-	
+
 	// Filter issues by regex
 	for _, issue := range response.Data.Repository.Issues.Nodes {
 		if re.MatchString(issue.Title) {

--- a/gh-helper/github.go
+++ b/gh-helper/github.go
@@ -308,7 +308,7 @@ func (c *GitHubClient) CreatePRConversationCommentREST(prNumber, body string) er
 		return fmt.Errorf("REST comment auth failed: %w", err)
 	}
 
-	payload, err := FormatJSON.Marshal(map[string]string{"body": body})
+	payload, err := json.Marshal(map[string]string{"body": body})
 	if err != nil {
 		return fmt.Errorf("failed to marshal REST comment request: %w", err)
 	}

--- a/gh-helper/github.go
+++ b/gh-helper/github.go
@@ -17,6 +17,8 @@ import (
 	"golang.org/x/net/http2"
 )
 
+const githubAPIUserAgent = "gh-dev-tools/1.0"
+
 // GitHubClient provides common GitHub operations with token caching
 type GitHubClient struct {
 	Owner        string
@@ -176,7 +178,7 @@ func (c *GitHubClient) RunGraphQLQueryWithVariables(query string, variables map[
 
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", "spanner-mycli-dev-tools/1.0")
+	req.Header.Set("User-Agent", githubAPIUserAgent)
 
 	// Execute request
 	resp, err := c.httpClient.Do(req)
@@ -320,7 +322,7 @@ func (c *GitHubClient) CreatePRConversationCommentREST(prNumber, body string) er
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	req.Header.Set("User-Agent", "spanner-mycli-dev-tools/1.0")
+	req.Header.Set("User-Agent", githubAPIUserAgent)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/gh-helper/main.go
+++ b/gh-helper/main.go
@@ -16,8 +16,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-
-
 // Helper functions for common patterns
 
 // resolvePRNumberFromArgs provides backwards compatibility wrapper
@@ -26,19 +24,19 @@ func resolvePRNumberFromArgs(args []string, client *GitHubClient) (string, error
 	if len(args) > 0 {
 		input = args[0]
 	}
-	
+
 	prNumberInt, _, err := client.ResolvePRNumber(input)
 	if err != nil {
 		return "", FetchError("PR number", err)
 	}
-	
+
 	// Suppress informational messages for structured output (YAML/JSON by default)
 	// These messages are for human-readable context only
-	
+
 	return fmt.Sprintf("%d", prNumberInt), nil
 }
 
-// parseTimeout provides backwards compatibility wrapper  
+// parseTimeout provides backwards compatibility wrapper
 func parseTimeout() (time.Duration, error) {
 	return ParseTimeoutString(timeoutStr)
 }
@@ -50,13 +48,13 @@ func calculateEffectiveTimeout() (time.Duration, string, error) {
 	if err != nil {
 		return 0, "", err
 	}
-	
+
 	// Show warning if timeout was constrained
 	if result.Requested > 0 && result.Effective != result.Requested {
-		WarningMsg("Requested timeout (%v) exceeds Claude Code limit. Using %v.", 
+		WarningMsg("Requested timeout (%v) exceeds Claude Code limit. Using %v.",
 			result.Requested, result.Effective).Print()
 	}
-	
+
 	return result.Effective, result.Display, nil
 }
 
@@ -88,7 +86,6 @@ var threadsCmd = &cobra.Command{
 	Short: "GitHub review thread operations",
 }
 
-
 var waitReviewsCmd = NewOperationalCommand(
 	"wait [pr-number]",
 	"Wait for both reviews and PR checks (default behavior)",
@@ -113,7 +110,6 @@ Default timeout is 5 minutes, configurable with --timeout flag.`,
 )
 
 // waitAllCmd removed - redundant with waitReviewsCmd which supports the same functionality
-
 
 var replyThreadsCmd = NewOperationalCommand(
 	"reply <thread-id> [<thread-id>...]",
@@ -166,7 +162,7 @@ Examples:
 
 var showThreadCmd = &cobra.Command{
 	Use:   "show <thread-id> [<thread-id>...]",
-	Short: "Show detailed view of one or more review threads", 
+	Short: "Show detailed view of one or more review threads",
 	Long: `Show detailed view of review threads including all comments.
 
 This command accepts one or more thread IDs, allowing you to inspect multiple
@@ -223,7 +219,7 @@ This command submits any pending review comments that haven't been published yet
 Pending comments are created when replying to threads with --no-submit flag or
 when using older tools that don't auto-submit reviews.
 
-` + prNumberArgsHelp + `
+`+prNumberArgsHelp+`
 
 Examples:
   # Submit all pending comments for current branch's PR
@@ -275,7 +271,7 @@ func init() {
 	replyThreadsCmd.Args = cobra.MinimumNArgs(1)
 	// showThreadCmd already configured with MinimumNArgs(1) in command definition
 	resolveThreadCmd.Args = cobra.MinimumNArgs(1)
-	
+
 	// Configure flags
 	rootCmd.PersistentFlags().StringVar(&owner, "owner", DefaultOwner, "GitHub repository owner")
 	rootCmd.PersistentFlags().StringVar(&repo, "repo", DefaultRepo, "GitHub repository name")
@@ -284,7 +280,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool("json", false, "Output JSON format (alias for --format=json)")
 	rootCmd.PersistentFlags().Bool("yaml", false, "Output YAML format (alias for --format=yaml)")
 	rootCmd.PersistentFlags().String("jq", "", "Apply jq query to filter/transform output")
-	
+
 	// Mark all format flags as mutually exclusive
 	rootCmd.MarkFlagsMutuallyExclusive("format", "json")
 	rootCmd.MarkFlagsMutuallyExclusive("format", "yaml")
@@ -309,7 +305,7 @@ func init() {
 	showThreadCmd.Flags().Bool("exclude-urls", false, "Exclude URLs from output")
 
 	// Add subcommands
-	reviewsCmd.AddCommand(fetchReviewsCmd, waitReviewsCmd)
+	reviewsCmd.AddCommand(fetchReviewsCmd, waitReviewsCmd, botStatusCmd)
 	threadsCmd.AddCommand(showThreadCmd, replyThreadsCmd, resolveThreadCmd, submitThreadsCmd)
 	rootCmd.AddCommand(reviewsCmd, threadsCmd, labelsCmd, issuesCmd, releasesCmd, nodeIDCmd)
 }
@@ -319,13 +315,12 @@ func main() {
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
 		Level: slog.LevelWarn,
 	})))
-	
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 }
-
 
 // getCurrentUser returns the current authenticated GitHub username
 func getCurrentUser() (string, error) {
@@ -341,10 +336,10 @@ type ReviewState struct {
 
 // DetailedStatus represents comprehensive PR status data
 type DetailedStatus struct {
-	PR       string           `json:"pr"`
-	Title    string           `json:"title"`
-	Timeline TimelineInfo     `json:"timeline"`
-	Checks   StatusChecks     `json:"checks"`
+	PR       string       `json:"pr"`
+	Title    string       `json:"title"`
+	Timeline TimelineInfo `json:"timeline"`
+	Checks   StatusChecks `json:"checks"`
 }
 
 // TimelineInfo represents important timestamps
@@ -356,11 +351,11 @@ type TimelineInfo struct {
 
 // StatusChecks represents all status checks
 type StatusChecks struct {
-	ReviewThreads   ThreadStatus         `json:"reviewThreads"`
-	Reviews         ReviewApprovalStatus `json:"reviews"`
-	CIStatus        CICheckStatus        `json:"ciStatus"`
-	Mergeability    MergeConflictStatus  `json:"mergeability"`
-	GeminiComments  CommentAnalysis      `json:"geminiComments,omitempty"`
+	ReviewThreads  ThreadStatus         `json:"reviewThreads"`
+	Reviews        ReviewApprovalStatus `json:"reviews"`
+	CIStatus       CICheckStatus        `json:"ciStatus"`
+	Mergeability   MergeConflictStatus  `json:"mergeability"`
+	GeminiComments CommentAnalysis      `json:"geminiComments,omitempty"`
 }
 
 // ThreadStatus represents review thread status
@@ -395,10 +390,10 @@ type MergeConflictStatus struct {
 
 // CommentAnalysis represents PR comment analysis
 type CommentAnalysis struct {
-	HasSummaryComment    bool             `json:"hasSummaryComment"`
-	HasReviewComment     bool             `json:"hasReviewComment"`
-	LastCommentIsSummary bool             `json:"lastCommentIsSummary"`
-	Comments             []PRCommentInfo  `json:"comments"`
+	HasSummaryComment    bool            `json:"hasSummaryComment"`
+	HasReviewComment     bool            `json:"hasReviewComment"`
+	LastCommentIsSummary bool            `json:"lastCommentIsSummary"`
+	Comments             []PRCommentInfo `json:"comments"`
 }
 
 // PRCommentInfo represents a PR comment
@@ -412,17 +407,17 @@ type PRCommentInfo struct {
 func loadReviewState(prNumber string) (*ReviewState, error) {
 	stateDir := filepath.Join(GetCacheDir(), "reviews")
 	lastReviewFile := filepath.Join(stateDir, fmt.Sprintf("pr-%s-last-review.json", prNumber))
-	
+
 	data, err := os.ReadFile(lastReviewFile)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	var state ReviewState
 	if err := Unmarshal(data, &state); err != nil {
 		return nil, err
 	}
-	
+
 	return &state, nil
 }
 
@@ -430,20 +425,20 @@ func loadReviewState(prNumber string) (*ReviewState, error) {
 func saveReviewState(prNumber string, state ReviewState) error {
 	stateDir := filepath.Join(GetCacheDir(), "reviews")
 	lastReviewFile := filepath.Join(stateDir, fmt.Sprintf("pr-%s-last-review.json", prNumber))
-	
+
 	if err := os.MkdirAll(stateDir, 0755); err != nil {
 		return fmt.Errorf("failed to create state directory: %w", err)
 	}
-	
+
 	data, err := yaml.MarshalWithOptions(state, yaml.UseJSONMarshaler())
 	if err != nil {
 		return fmt.Errorf("failed to marshal state: %w", err)
 	}
-	
+
 	if err := os.WriteFile(lastReviewFile, data, 0644); err != nil {
 		return fmt.Errorf("failed to write state file: %w", err)
 	}
-	
+
 	return nil
 }
 
@@ -453,14 +448,14 @@ func hasNewReviews(reviews []ReviewFields, lastState *ReviewState) bool {
 		// No previous state, any review is "new"
 		return len(reviews) > 0
 	}
-	
+
 	for _, review := range reviews {
 		if review.CreatedAt > lastState.CreatedAt ||
 			(review.CreatedAt == lastState.CreatedAt && review.ID != lastState.ID) {
 			return true
 		}
 	}
-	
+
 	return false
 }
 
@@ -469,7 +464,7 @@ func hasNewReviews(reviews []ReviewFields, lastState *ReviewState) bool {
 //
 // Key findings from anthropics/claude-code#1039, anthropics/claude-code#1216, anthropics/claude-code#1717:
 // - BASH_MAX_TIMEOUT_MS: Upper limit for explicit timeout requests (our use case)
-// - BASH_DEFAULT_TIMEOUT_MS: Default timeout when no explicit timeout specified  
+// - BASH_DEFAULT_TIMEOUT_MS: Default timeout when no explicit timeout specified
 // - Claude Code defaults to 2-minute hard limit when no env vars are set
 // - Environment variables are read from ~/.claude/settings.json or project .claude/settings.json
 // - Project settings should be committed, local settings (.claude/settings.local.json) should not
@@ -481,7 +476,7 @@ func checkClaudeCodeEnvironment() (time.Duration, bool) {
 		fmt.Printf("🔧 Claude Code BASH_MAX_TIMEOUT_MS detected: %v\n", maxTimeout)
 		return maxTimeout, true
 	}
-	
+
 	// Check for BASH_DEFAULT_TIMEOUT_MS (default when no timeout specified)
 	if defaultTimeout, err := ParseClaudeCodeTimeoutEnv("BASH_DEFAULT_TIMEOUT_MS"); err != nil {
 		fmt.Printf("⚠️  %v\n", err)
@@ -489,7 +484,7 @@ func checkClaudeCodeEnvironment() (time.Duration, bool) {
 		fmt.Printf("🔧 Claude Code BASH_DEFAULT_TIMEOUT_MS detected: %v\n", defaultTimeout)
 		return defaultTimeout, true
 	}
-	
+
 	return 0, false
 }
 
@@ -568,42 +563,42 @@ func performAsyncReviewCheck(client *GitHubClient, prNumber string) error {
 // performDetailedStatusCheck performs comprehensive status check including PR comments
 func performDetailedStatusCheck(cmd *cobra.Command, client *GitHubClient, prNumber string) error {
 	StatusMsg("Collecting detailed status for PR #%s...", prNumber).Print()
-	
+
 	// Convert PR number to integer
 	prNumberInt, err := strconv.Atoi(prNumber)
 	if err != nil {
 		return fmt.Errorf("invalid PR number format: %w", err)
 	}
-	
+
 	// Fetch comprehensive PR data
 	config := NewPRQueryConfig(owner, repo, prNumberInt).
 		ForReviewsAndStatus().
 		WithThreads().
 		WithComments()
-	
+
 	response, err := client.FetchPRData(config)
 	if err != nil {
 		return fmt.Errorf("failed to fetch PR data: %w", err)
 	}
-	
+
 	// Build detailed status
 	status := DetailedStatus{
 		PR:    prNumber,
 		Title: response.GetTitle(),
 	}
-	
+
 	// Timeline information
 	status.Timeline = TimelineInfo{
 		PRCreated: response.GetCreatedAt(),
 		LastPush:  response.GetLastPushAt(),
 	}
-	
+
 	// Review threads status
 	threads := response.GetThreads()
 	resolved := 0
 	unresolved := 0
 	var lastResolvedTime string
-	
+
 	for _, thread := range threads {
 		if thread.IsResolved {
 			resolved++
@@ -618,9 +613,9 @@ func performDetailedStatusCheck(cmd *cobra.Command, client *GitHubClient, prNumb
 			unresolved++
 		}
 	}
-	
+
 	status.Timeline.LastReviewThreadResolved = lastResolvedTime
-	
+
 	threadStatus := "pass"
 	if unresolved > 0 {
 		threadStatus = "fail"
@@ -630,12 +625,12 @@ func performDetailedStatusCheck(cmd *cobra.Command, client *GitHubClient, prNumb
 		Resolved:   resolved,
 		Unresolved: unresolved,
 	}
-	
+
 	// Reviews status
 	reviews := response.GetReviews()
 	approved := 0
 	changesRequested := 0
-	
+
 	// Track latest review per author
 	latestReviews := make(map[string]ReviewFields)
 	for _, review := range reviews {
@@ -643,7 +638,7 @@ func performDetailedStatusCheck(cmd *cobra.Command, client *GitHubClient, prNumb
 			latestReviews[review.Author.Login] = review
 		}
 	}
-	
+
 	// Count current state
 	for _, review := range latestReviews {
 		switch review.State {
@@ -653,26 +648,26 @@ func performDetailedStatusCheck(cmd *cobra.Command, client *GitHubClient, prNumb
 			changesRequested++
 		}
 	}
-	
+
 	// TODO: Get required reviews from branch protection rules
 	// For now, assume 1 required
 	required := 1
-	
+
 	reviewStatus := "pass"
 	if changesRequested > 0 || approved < required {
 		reviewStatus = "fail"
 	}
-	
+
 	status.Checks.Reviews = ReviewApprovalStatus{
 		Status:           reviewStatus,
 		Required:         required,
 		Approved:         approved,
 		ChangesRequested: changesRequested,
 	}
-	
+
 	// Get merge status first as it's needed for CI status determination
 	mergeable, mergeState := response.GetMergeStatus()
-	
+
 	// CI Status
 	statusCheckRollup := response.GetStatusCheckRollup()
 	if statusCheckRollup != nil {
@@ -680,12 +675,12 @@ func performDetailedStatusCheck(cmd *cobra.Command, client *GitHubClient, prNumb
 		var passed []string
 		var failed []string
 		var required []string
-		
+
 		// Extract check information from contexts
 		for _, context := range statusCheckRollup.Contexts.Nodes {
 			contextName := ""
 			contextState := ""
-			
+
 			switch context.Typename {
 			case "StatusContext":
 				contextName = context.Context
@@ -708,12 +703,12 @@ func performDetailedStatusCheck(cmd *cobra.Command, client *GitHubClient, prNumb
 					contextState = "PENDING"
 				}
 			}
-			
+
 			if contextName != "" {
 				if context.IsRequired {
 					required = append(required, contextName)
 				}
-				
+
 				switch contextState {
 				case "SUCCESS":
 					passed = append(passed, contextName)
@@ -729,7 +724,7 @@ func performDetailedStatusCheck(cmd *cobra.Command, client *GitHubClient, prNumb
 				}
 			}
 		}
-		
+
 		status.Checks.CIStatus = CICheckStatus{
 			Status:   ciStatus,
 			Required: required,
@@ -739,12 +734,12 @@ func performDetailedStatusCheck(cmd *cobra.Command, client *GitHubClient, prNumb
 	} else {
 		// No statusCheckRollup - determine if checks are pending or not configured
 		ciStatus := "pass"
-		
+
 		// Check merge state to determine if checks are pending
 		if mergeState == "BLOCKED" || mergeState == "UNKNOWN" {
 			ciStatus = "pending"
 		}
-		
+
 		status.Checks.CIStatus = CICheckStatus{
 			Status:   ciStatus,
 			Required: []string{},
@@ -752,11 +747,11 @@ func performDetailedStatusCheck(cmd *cobra.Command, client *GitHubClient, prNumb
 			Failed:   []string{},
 		}
 	}
-	
+
 	// Mergeability (already fetched above)
 	mergeStatus := "pass"
 	conflicts := false
-	
+
 	switch mergeable {
 	case "CONFLICTING":
 		mergeStatus = "fail"
@@ -764,20 +759,20 @@ func performDetailedStatusCheck(cmd *cobra.Command, client *GitHubClient, prNumb
 	case "UNKNOWN":
 		mergeStatus = "pending"
 	}
-	
+
 	status.Checks.Mergeability = MergeConflictStatus{
 		Status:    mergeStatus,
 		Conflicts: conflicts,
 		State:     mergeState,
 	}
-	
+
 	// PR Comments Analysis
 	comments := response.GetComments()
 	if len(comments) > 0 {
 		analysis := CommentAnalysis{
 			Comments: []PRCommentInfo{},
 		}
-		
+
 		for _, comment := range comments {
 			// Categorize comment
 			commentType := "comment"
@@ -788,67 +783,67 @@ func performDetailedStatusCheck(cmd *cobra.Command, client *GitHubClient, prNumb
 				commentType = "review"
 				analysis.HasReviewComment = true
 			}
-			
+
 			analysis.Comments = append(analysis.Comments, PRCommentInfo{
 				Type:      commentType,
 				Timestamp: comment.CreatedAt,
 				Body:      comment.Body,
 			})
 		}
-		
+
 		// Check if last comment is summary
 		if len(analysis.Comments) > 0 {
 			lastComment := analysis.Comments[len(analysis.Comments)-1]
 			analysis.LastCommentIsSummary = lastComment.Type == "summary"
 		}
-		
+
 		status.Checks.GeminiComments = analysis
 	}
-	
+
 	// Output the detailed status
 	output := map[string]interface{}{
 		"detailedStatus": status,
 	}
-	
+
 	return EncodeOutputWithCmd(cmd, output)
 }
 
 // performRequestSummaryAndWait requests a Gemini summary and waits for it
 func performRequestSummaryAndWait(cmd *cobra.Command, client *GitHubClient, prNumber string) error {
 	fmt.Printf("📝 Requesting Gemini summary for PR #%s...\n", prNumber)
-	
+
 	// Post /gemini summary comment
 	if err := client.CreatePRComment(prNumber, "/gemini summary"); err != nil {
 		return fmt.Errorf("failed to request Gemini summary: %w", err)
 	}
-	
+
 	fmt.Println("✅ Gemini summary requested")
 	fmt.Println("⏳ Waiting for summary to be posted...")
-	
+
 	// Convert PR number to integer
 	prNumberInt, err := strconv.Atoi(prNumber)
 	if err != nil {
 		return fmt.Errorf("invalid PR number format: %w", err)
 	}
-	
+
 	// Calculate timeout
 	effectiveTimeout, timeoutDisplay, err := calculateEffectiveTimeout()
 	if err != nil {
 		return err
 	}
-	
+
 	fmt.Printf("🔄 Waiting for summary (timeout: %s)...\n", timeoutDisplay)
-	
+
 	// Get initial comments count
 	config := NewPRQueryConfig(owner, repo, prNumberInt).WithComments()
 	initialResponse, err := client.FetchPRData(config)
 	if err != nil {
 		return fmt.Errorf("failed to fetch initial PR data: %w", err)
 	}
-	
+
 	initialComments := initialResponse.GetComments()
 	initialCount := len(initialComments)
-	
+
 	// Check if there's already a summary in the last few comments
 	foundExistingSummary := false
 	for i := len(initialComments) - 1; i >= 0 && i >= len(initialComments)-3; i-- {
@@ -857,14 +852,14 @@ func performRequestSummaryAndWait(cmd *cobra.Command, client *GitHubClient, prNu
 			break
 		}
 	}
-	
+
 	if foundExistingSummary {
 		fmt.Println("✅ Found existing summary in recent comments")
 		return nil
 	}
-	
+
 	startTime := time.Now()
-	
+
 	// Poll for new summary comment
 	for {
 		// Check timeout
@@ -872,39 +867,39 @@ func performRequestSummaryAndWait(cmd *cobra.Command, client *GitHubClient, prNu
 			fmt.Printf("\n⏰ Timeout reached (%v). Summary not posted yet.\n", effectiveTimeout)
 			return fmt.Errorf("timeout waiting for Gemini summary")
 		}
-		
+
 		// Wait before checking
 		time.Sleep(5 * time.Second)
-		
+
 		// Fetch updated comments
 		response, err := client.FetchPRData(config)
 		if err != nil {
 			fmt.Printf("Error fetching PR data: %v\n", err)
 			continue
 		}
-		
+
 		comments := response.GetComments()
-		
+
 		// Check for new comments
 		if len(comments) > initialCount {
 			// Check new comments for summary
 			for i := initialCount; i < len(comments); i++ {
 				if strings.Contains(comments[i].Body, geminiSummaryHeader) {
-					fmt.Printf("\n🎉 Summary posted by %s at %s\n", 
+					fmt.Printf("\n🎉 Summary posted by %s at %s\n",
 						comments[i].Author.Login, comments[i].CreatedAt)
-					
+
 					// Show preview
 					preview := comments[i].Body
 					if len(preview) > 200 {
 						preview = preview[:200] + "..."
 					}
 					fmt.Printf("\nPreview:\n%s\n", preview)
-					
+
 					return nil
 				}
 			}
 		}
-		
+
 		elapsed := time.Since(startTime)
 		remaining := effectiveTimeout - elapsed
 		fmt.Printf("[%s] Waiting for summary... (remaining: %v)\n",
@@ -918,22 +913,22 @@ func waitForReviews(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	
+
 	// Validate flags
 	if excludeReviews && excludeChecks {
 		return fmt.Errorf("cannot exclude both reviews and checks")
 	}
-	
+
 	// Validate mutually exclusive flags
 	if requestSummary && async {
 		return fmt.Errorf("--request-summary and --async are mutually exclusive")
 	}
-	
+
 	// Validate --detailed requires --async
 	if detailed && !async {
 		return fmt.Errorf("--detailed requires --async")
 	}
-	
+
 	// Handle async mode - single check and return (replaces reviews check)
 	if async {
 		if detailed {
@@ -946,25 +941,23 @@ func waitForReviews(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("async mode currently only supports review checking")
 		}
 	}
-	
+
 	// Handle request-summary mode
 	if requestSummary {
 		return performRequestSummaryAndWait(cmd, client, prNumber)
 	}
-	
+
 	// Determine what to wait for
 	waitForReviews := !excludeReviews
 	waitForChecks := !excludeChecks
-	
+
 	// Request Gemini review if flag is set
 	if requestReview && waitForReviews {
-		fmt.Printf("📝 Requesting Gemini review for PR #%s...\n", prNumber)
-		if err := client.CreatePRComment(prNumber, "/gemini review"); err != nil {
-			return fmt.Errorf("failed to request Gemini review: %w", err)
+		if err := requestGeminiReviewForCurrentHead(client, prNumber); err != nil {
+			return err
 		}
-		fmt.Println("✅ Gemini review requested")
 	}
-	
+
 	// Display what we're waiting for
 	waitingFor := []string{}
 	if waitForReviews {
@@ -973,34 +966,34 @@ func waitForReviews(cmd *cobra.Command, args []string) error {
 	if waitForChecks {
 		waitingFor = append(waitingFor, "PR checks")
 	}
-	
+
 	// Calculate timeout with Claude Code constraints
 	_, timeoutDisplay, err := calculateEffectiveTimeout()
 	if err != nil {
 		return err
 	}
-	
-	fmt.Printf("🔄 Waiting for %s on PR #%s (timeout: %s)...\n", 
+
+	fmt.Printf("🔄 Waiting for %s on PR #%s (timeout: %s)...\n",
 		strings.Join(waitingFor, " and "), prNumber, timeoutDisplay)
 	fmt.Println("Press Ctrl+C to stop monitoring")
 
 	// For now, simply delegate to waitForReviewsAndChecks with appropriate flags
 	// This ensures the new default behavior (both reviews and checks) works
-	
+
 	// Temporarily override global flags for delegation
 	originalRequestReview := requestReview
 	defer func() { requestReview = originalRequestReview }()
-	
+
 	// Disable review request in delegated function since we already handled it above
 	requestReview = false
-	
+
 	// If we're only waiting for reviews, use the original simpler logic
 	if waitForReviews && !waitForChecks {
 		fmt.Printf("⚠️  Reviews-only mode: Using simplified wait logic\n")
 		// Simple polling for reviews only (original behavior)
 		return waitForReviewsOnly(prNumber)
 	}
-	
+
 	// For all other cases (checks-only or both), delegate to the full implementation
 	err = waitForReviewsAndChecks(cmd, args)
 	// Don't wrap the error to avoid double error messages
@@ -1014,25 +1007,25 @@ func waitForReviewsOnly(prNumber string) error {
 	if err != nil {
 		return fmt.Errorf("invalid PR number format: %w", err)
 	}
-	
+
 	// Create GitHub client once for better performance (token caching)
 	client := NewGitHubClient(owner, repo)
-	
+
 	// Apply Claude Code timeout constraints
 	effectiveTimeout, timeoutDisplay, err := calculateEffectiveTimeout()
 	if err != nil {
 		return err
 	}
-	
+
 	fmt.Printf("🔄 Waiting for reviews only on PR #%s (timeout: %s)...\n", prNumber, timeoutDisplay)
 	fmt.Println("Press Ctrl+C to stop monitoring")
-	
+
 	// Load existing state
 	lastState, err := loadReviewState(prNumber)
 	if err == nil {
 		fmt.Printf("📊 Tracking reviews since: %s\n", lastState.CreatedAt)
 	}
-	
+
 	startTime := time.Now()
 	for {
 		// Check timeout
@@ -1040,7 +1033,7 @@ func waitForReviewsOnly(prNumber string) error {
 			fmt.Printf("\n⏰ Timeout reached (%v). No new reviews found.\n", effectiveTimeout)
 			return nil
 		}
-		
+
 		// Use unified architecture for review polling
 		config := NewPRQueryConfig(owner, repo, prNumberInt).ForReviewsOnly()
 		response, err := client.FetchPRData(config)
@@ -1049,9 +1042,9 @@ func waitForReviewsOnly(prNumber string) error {
 			time.Sleep(30 * time.Second)
 			continue
 		}
-		
+
 		reviews := response.GetReviews()
-		
+
 		if hasNewReviews(reviews, lastState) {
 			// Find and display new reviews
 			if lastState == nil {
@@ -1069,7 +1062,7 @@ func waitForReviewsOnly(prNumber string) error {
 					}
 				}
 			}
-			
+
 			// Update state with latest review
 			if len(reviews) > 0 {
 				latestReview := reviews[len(reviews)-1]
@@ -1079,18 +1072,18 @@ func waitForReviewsOnly(prNumber string) error {
 				}
 				_ = saveReviewState(prNumber, newState) // Best effort state save
 			}
-			
+
 			fmt.Println("\n✅ New reviews available!")
 			ListThreadsGuidance(prNumber).Print()
 			fmt.Println("⚠️  IMPORTANT: Please read the review feedback carefully before proceeding")
 			return nil
 		}
-		
+
 		elapsed := time.Since(startTime)
 		remaining := effectiveTimeout - elapsed
 		fmt.Printf("[%s] No new reviews yet (remaining: %v)\n",
 			time.Now().Format("15:04:05"), remaining.Truncate(time.Second))
-		
+
 		time.Sleep(30 * time.Second)
 	}
 }
@@ -1102,7 +1095,7 @@ var (
 		"CONFLICTING": "❌ Has conflicts",
 		"UNKNOWN":     "⏳ Checking...",
 	}
-	
+
 	// Note: Status formatting moved to FormatStatusState()
 	// for reuse across dev-tools
 )
@@ -1115,7 +1108,7 @@ func getStatusMessage(state string, withIcon bool) string {
 func waitForReviewsAndChecks(cmd *cobra.Command, args []string) error {
 	// Create GitHub client once for better performance (token caching)
 	client := NewGitHubClient(owner, repo)
-	
+
 	prNumber, err := resolvePRNumberFromArgs(args, client)
 	if err != nil {
 		return err
@@ -1126,13 +1119,13 @@ func waitForReviewsAndChecks(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("invalid PR number format: %w", err)
 	}
-	
+
 	// Calculate timeout with Claude Code constraints
 	effectiveTimeout, timeoutDisplay, err := calculateEffectiveTimeout()
 	if err != nil {
 		return err
 	}
-	
+
 	// Show additional guidance for extending timeout if needed
 	timeoutDuration, parseErr := parseTimeout()
 	if parseErr == nil && effectiveTimeout < timeoutDuration {
@@ -1140,23 +1133,21 @@ func waitForReviewsAndChecks(cmd *cobra.Command, args []string) error {
 		fmt.Printf("💡 Example: {\"env\": {\"BASH_MAX_TIMEOUT_MS\": \"900000\"}} for 15 minutes\n")
 		fmt.Printf("💡 Manual retry: bin/gh-helper reviews wait %s --timeout=%v\n", prNumber, timeoutDuration)
 	}
-	
+
 	// Request Gemini review if flag is set
 	if requestReview {
-		fmt.Printf("📝 Requesting Gemini review for PR #%s...\n", prNumber)
-		if err := client.CreatePRComment(prNumber, "/gemini review"); err != nil {
-			return fmt.Errorf("failed to request Gemini review: %w", err)
+		if err := requestGeminiReviewForCurrentHead(client, prNumber); err != nil {
+			return err
 		}
-		fmt.Println("✅ Gemini review requested")
 	}
-	
+
 	fmt.Printf("🔄 Waiting for both reviews AND PR checks for PR #%s (timeout: %s)...\n", prNumber, timeoutDisplay)
 	fmt.Println("Press Ctrl+C to stop monitoring")
 
 	// Setup signal handling for graceful termination with proper guidance
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-	
+
 	// Exit code 130 is standard for SIGINT (Ctrl+C)
 	go func() {
 		sig := <-sigChan
@@ -1232,10 +1223,10 @@ func waitForReviewsAndChecks(cmd *cobra.Command, args []string) error {
 			// 1. No checks are configured for this repository (truly complete)
 			// 2. Checks are configured but haven't started yet (not complete)
 			// 3. PR was just created or pushed (checks pending)
-			
+
 			// Check merge status for better determination
 			mergeable, mergeStatus := response.GetMergeStatus()
-			
+
 			// If PR has conflicts, checks won't run until resolved
 			if mergeable == "CONFLICTING" {
 				checksComplete = true // No point waiting for checks that won't run
@@ -1252,15 +1243,15 @@ func waitForReviewsAndChecks(cmd *cobra.Command, args []string) error {
 		if initialCheck {
 			fmt.Printf("[%s] Monitoring started.\n", time.Now().Format("15:04:05"))
 			fmt.Printf("   Reviews: %d found, Ready: %v\n", len(reviews), reviewsReady)
-			
+
 			// Show mergeable status
 			mergeable, mergeStatus := response.GetMergeStatus()
-			
+
 			msg, exists := mergeStatusMessages[mergeable]
 			if !exists {
 				msg = mergeable // Use raw value for unknown states
 			}
-			
+
 			if mergeable == "CONFLICTING" {
 				fmt.Printf("   Merge: %s (status: %s)\n", msg, mergeStatus)
 			} else {
@@ -1268,7 +1259,7 @@ func waitForReviewsAndChecks(cmd *cobra.Command, args []string) error {
 			}
 			if statusCheckRollup != nil {
 				rollupState := statusCheckRollup.State
-				
+
 				statusMsg := getStatusMessage(rollupState, false)
 				fmt.Printf("   Checks: %s, Complete: %v\n", statusMsg, checksComplete)
 			} else {
@@ -1280,19 +1271,19 @@ func waitForReviewsAndChecks(cmd *cobra.Command, args []string) error {
 		// Check if both conditions are met
 		if reviewsReady && checksComplete {
 			fmt.Printf("\n🎉 [%s] Both reviews and checks are ready!\n", time.Now().Format("15:04:05"))
-			
+
 			if reviewsReady {
 				fmt.Println("✅ Reviews: New reviews available")
-				
+
 				// Output review details to reduce subsequent API calls
 				fmt.Println("\n📋 Recent Reviews:")
 				for i, review := range reviews {
 					if i >= 5 { // Limit to 5 most recent reviews
 						break
 					}
-					fmt.Printf("   • %s by %s (%s) - %s\n", 
-						review.ID, 
-						review.Author.Login, 
+					fmt.Printf("   • %s by %s (%s) - %s\n",
+						review.ID,
+						review.Author.Login,
 						review.State,
 						review.CreatedAt)
 					if review.Body != "" && len(review.Body) > 100 {
@@ -1301,12 +1292,12 @@ func waitForReviewsAndChecks(cmd *cobra.Command, args []string) error {
 						fmt.Printf("     Preview: %s\n", review.Body)
 					}
 				}
-				
+
 				fmt.Println()
 				ListThreadsGuidance(prNumber).Print()
 				fmt.Println("⚠️  IMPORTANT: Please read the review feedback carefully before proceeding")
 			}
-			
+
 			// Show merge conflicts warning if present
 			mergeable, _ := response.GetMergeStatus()
 			if mergeable == "CONFLICTING" {
@@ -1316,13 +1307,13 @@ func waitForReviewsAndChecks(cmd *cobra.Command, args []string) error {
 			if checksComplete {
 				if statusCheckRollup != nil {
 					rollupState := statusCheckRollup.State
-					
+
 					fmt.Printf("Checks: %s\n", getStatusMessage(rollupState, true))
 				} else {
 					fmt.Println("✅ Checks: No checks required")
 				}
 			}
-			
+
 			return nil
 		}
 
@@ -1330,11 +1321,10 @@ func waitForReviewsAndChecks(cmd *cobra.Command, args []string) error {
 		remaining := timeoutDuration - elapsed
 		fmt.Printf("[%s] Status: Reviews: %v, Checks: %v (remaining: %v)\n",
 			time.Now().Format("15:04:05"), reviewsReady, checksComplete, remaining.Truncate(time.Second))
-		
+
 		time.Sleep(30 * time.Second)
 	}
 }
-
 
 func showThread(cmd *cobra.Command, args []string) error {
 	// Create GitHub client once for better performance (token caching)
@@ -1355,9 +1345,9 @@ func showThread(cmd *cobra.Command, args []string) error {
 
 	// Get current user for reply detection
 	currentUser, _ := getCurrentUser()
-	
+
 	results := []map[string]interface{}{}
-	
+
 	// Process each thread ID in order
 	for _, threadID := range args {
 		thread, exists := threadsMap[threadID]
@@ -1372,16 +1362,16 @@ func showThread(cmd *cobra.Command, args []string) error {
 			"path":       thread.Path,
 			"line":       thread.Line,
 		}
-		
+
 		// Include URL only if not empty (respects @skip directive)
 		if thread.URL != "" {
 			output["url"] = thread.URL
 		}
-		
+
 		if thread.SubjectType != "" {
 			output["subjectType"] = thread.SubjectType
 		}
-		
+
 		// Comments using GitHub GraphQL structure
 		comments := []map[string]interface{}{}
 		for i, comment := range thread.Comments {
@@ -1391,24 +1381,24 @@ func showThread(cmd *cobra.Command, args []string) error {
 				"createdAt": comment.CreatedAt,
 				"body":      comment.Body,
 			}
-			
+
 			// Include URL only if not empty (respects @skip directive)
 			if comment.URL != "" {
 				commentData["url"] = comment.URL
 			}
-			
+
 			if i == 0 && comment.DiffHunk != "" {
 				commentData["diffHunk"] = comment.DiffHunk
 			}
-			
+
 			comments = append(comments, commentData)
 		}
-		
+
 		output["comments"] = map[string]interface{}{
 			"nodes":      comments,
 			"totalCount": len(comments),
 		}
-		
+
 		// Check if needs reply
 		if !thread.IsResolved && len(thread.Comments) > 0 {
 			lastComment := thread.Comments[len(thread.Comments)-1]
@@ -1417,15 +1407,15 @@ func showThread(cmd *cobra.Command, args []string) error {
 				output["lastCommentBy"] = lastComment.Author
 			}
 		}
-		
+
 		results = append(results, output)
 	}
-	
+
 	// Output single result for backward compatibility when only one thread
 	if len(results) == 1 {
 		return EncodeOutputWithCmd(cmd, results[0])
 	}
-	
+
 	// Output array for multiple threads
 	return EncodeOutputWithCmd(cmd, results)
 }
@@ -1433,11 +1423,11 @@ func showThread(cmd *cobra.Command, args []string) error {
 func resolveThread(cmd *cobra.Command, args []string) error {
 	// Create GitHub client
 	client := NewGitHubClient(owner, repo)
-	
+
 	// Get output format using unified resolver
 	resolvedAt := time.Now().Format("2006-01-02T15:04:05Z07:00")
 	results := []map[string]interface{}{}
-	
+
 	// Process each thread ID
 	for _, threadID := range args {
 		if err := client.ResolveThread(threadID); err != nil {
@@ -1451,12 +1441,12 @@ func resolveThread(cmd *cobra.Command, args []string) error {
 			"resolvedAt": resolvedAt,
 		})
 	}
-	
+
 	// Output single result for backward compatibility when only one thread
 	if len(results) == 1 {
 		return EncodeOutputWithCmd(cmd, results[0])
 	}
-	
+
 	// Output array for multiple threads
 	return EncodeOutputWithCmd(cmd, results)
 }
@@ -1464,19 +1454,19 @@ func resolveThread(cmd *cobra.Command, args []string) error {
 func submitPendingComments(cmd *cobra.Command, args []string) error {
 	// Create GitHub client
 	client := NewGitHubClient(owner, repo)
-	
+
 	// Resolve PR number
 	prNumber, err := resolvePRNumberFromArgs(args, client)
 	if err != nil {
 		return err
 	}
-	
+
 	// Get PR ID for the submit mutation
 	prNumberInt, err := strconv.Atoi(prNumber)
 	if err != nil {
 		return fmt.Errorf("invalid PR number: %w", err)
 	}
-	
+
 	// Query to get any pending reviews (optimized to fetch only required fields)
 	// Using first: 100 to handle most cases without pagination
 	// For extremely rare cases with >100 pending reviews, pagination would be needed
@@ -1512,19 +1502,19 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
 		"repo":     repo,
 		"prNumber": prNumberInt,
 	}
-	
+
 	result, err := client.RunGraphQLQueryWithVariables(query, variables)
 	if err != nil {
 		return fmt.Errorf("failed to fetch PR data: %w", err)
 	}
-	
+
 	var response struct {
 		Data struct {
 			Repository struct {
 				PullRequest struct {
 					Reviews struct {
 						TotalCount int `json:"totalCount"`
-						PageInfo struct {
+						PageInfo   struct {
 							HasNextPage bool   `json:"hasNextPage"`
 							EndCursor   string `json:"endCursor"`
 						} `json:"pageInfo"`
@@ -1545,30 +1535,30 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
 			} `json:"viewer"`
 		} `json:"data"`
 	}
-	
+
 	if err := Unmarshal(result, &response); err != nil {
 		return fmt.Errorf("failed to parse response: %w", err)
 	}
-	
+
 	// prID := response.Data.Repository.PullRequest.ID // Not needed for current implementation
 	currentUser := response.Data.Viewer.Login
 	reviews := response.Data.Repository.PullRequest.Reviews
 	pendingReviews := reviews.Nodes
-	
+
 	// Warn if there are more pending reviews than we fetched
 	if reviews.PageInfo.HasNextPage {
 		WarningMsg("More than 100 pending reviews found (total: %d). Only processing first 100.", reviews.TotalCount).Print()
 		WarningMsg("Consider running this command multiple times or implementing full pagination.").Print()
 	}
-	
+
 	if len(pendingReviews) == 0 {
 		InfoMsg("No pending reviews found for PR #%s", prNumber).Print()
 		return EncodeOutputWithCmd(cmd, map[string]interface{}{
-			"message": "No pending reviews to submit",
+			"message":  "No pending reviews to submit",
 			"prNumber": prNumber,
 		})
 	}
-	
+
 	// Define the mutation outside the loop for better performance
 	submitMutation := `
 mutation($reviewID: ID!) {
@@ -1600,7 +1590,7 @@ mutation($reviewID: ID!) {
 	// Submit each pending review owned by the current user
 	submittedCount := 0
 	results := []map[string]interface{}{}
-	
+
 	for _, review := range pendingReviews {
 		// Only submit reviews owned by the current user
 		if review.Author.Login != currentUser {
@@ -1613,63 +1603,63 @@ mutation($reviewID: ID!) {
 			})
 			continue
 		}
-		
+
 		// Since the review state is PENDING, all its comments are also pending.
 		// Using TotalCount is more accurate as it's not limited by pagination (first: 100).
 		pendingCommentCount := review.Comments.TotalCount
-		
+
 		// Submit the review
 		submitVars := map[string]interface{}{
 			"reviewID": review.ID,
 		}
-		
+
 		submitResult, err := client.RunGraphQLQueryWithVariables(submitMutation, submitVars)
 		if err != nil {
 			WarningMsg("Failed to submit review %s: %v", review.ID, err).Print()
 			results = append(results, map[string]interface{}{
-				"reviewId":             review.ID,
-				"status":               "failed",
-				"error":                err.Error(),
-				"pendingCommentCount":  pendingCommentCount,
+				"reviewId":            review.ID,
+				"status":              "failed",
+				"error":               err.Error(),
+				"pendingCommentCount": pendingCommentCount,
 			})
 			continue
 		}
-		
+
 		var submitResponse submitResponseType
-		
+
 		if err := Unmarshal(submitResult, &submitResponse); err != nil {
 			WarningMsg("Failed to parse submit response: %v", err).Print()
 			continue
 		}
-		
+
 		submittedReview := submitResponse.Data.SubmitPullRequestReview.PullRequestReview
 		submittedCount++
-		
+
 		results = append(results, map[string]interface{}{
-			"reviewId":            submittedReview.ID,
-			"status":              "submitted",
-			"state":               submittedReview.State,
-			"submittedAt":         submittedReview.SubmittedAt,
-			"commentsPublished":   review.Comments.TotalCount,
+			"reviewId":          submittedReview.ID,
+			"status":            "submitted",
+			"state":             submittedReview.State,
+			"submittedAt":       submittedReview.SubmittedAt,
+			"commentsPublished": review.Comments.TotalCount,
 		})
-		
+
 		SuccessMsg("Submitted pending review %s (%d comments published)", review.ID, review.Comments.TotalCount).Print()
 	}
-	
+
 	// Summary output
 	output := map[string]interface{}{
-		"prNumber":           prNumber,
+		"prNumber":            prNumber,
 		"pendingReviewsFound": len(pendingReviews),
-		"reviewsSubmitted":   submittedCount,
-		"results":            results,
+		"reviewsSubmitted":    submittedCount,
+		"results":             results,
 	}
-	
+
 	if submittedCount > 0 {
 		output["message"] = fmt.Sprintf("Successfully submitted %d pending review(s)", submittedCount)
 	} else {
 		output["message"] = "No reviews were submitted (none owned by current user)"
 	}
-	
+
 	return EncodeOutputWithCmd(cmd, output)
 }
 
@@ -1795,7 +1785,7 @@ func replyToThread(cmd *cobra.Command, args []string) error {
 		if result.Status == "failed" {
 			return fmt.Errorf("failed to reply to thread: %s", result.Error)
 		}
-		
+
 		outputData := map[string]interface{}{
 			"threadId":  result.ThreadID,
 			"commentId": result.CommentID,
@@ -1837,7 +1827,7 @@ func executeReplyMutation(client *GitHubClient, threadID, body string, result *r
 	// Use the ReplyToThread method which handles intelligent auto-submit
 	// Auto-submit is enabled by default (inverted from noSubmit flag)
 	autoSubmit := !noSubmit
-	
+
 	commentID, commentURL, err := client.ReplyToThread(threadID, body, autoSubmit)
 	if err != nil {
 		return err
@@ -1848,13 +1838,13 @@ func executeReplyMutation(client *GitHubClient, threadID, body string, result *r
 	result.Message = body
 	result.CommentID = commentID
 	result.URL = commentURL
-	
+
 	// Note: With the improved implementation, comments are only pending if there was
 	// already a pending review. The ReplyToThread method handles this intelligently.
 	if !autoSubmit {
 		InfoMsg("Auto-submit disabled. Comment may be pending if added to an existing pending review.").Print()
 	}
-	
+
 	return nil
 }
 
@@ -1888,4 +1878,3 @@ func countResolved(results []replyResult) int {
 	}
 	return count
 }
-

--- a/gh-helper/queries/bot_review_metadata.graphql
+++ b/gh-helper/queries/bot_review_metadata.graphql
@@ -1,0 +1,33 @@
+query($owner: String!, $repo: String!, $prNumber: Int!, $reviewBefore: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $prNumber) {
+      number
+      title
+      commits(last: 1) {
+        nodes {
+          commit {
+            oid
+          }
+        }
+      }
+      reviews(last: 100, before: $reviewBefore) {
+        pageInfo {
+          hasPreviousPage
+          startCursor
+        }
+        nodes {
+          id
+          author {
+            login
+          }
+          state
+          body
+          createdAt
+          commit {
+            oid
+          }
+        }
+      }
+    }
+  }
+}

--- a/gh-helper/queries/bot_review_threads.graphql
+++ b/gh-helper/queries/bot_review_threads.graphql
@@ -1,0 +1,37 @@
+query($owner: String!, $repo: String!, $prNumber: Int!, $threadAfter: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $prNumber) {
+      reviewThreads(first: 100, after: $threadAfter) {
+        nodes {
+          id
+          path
+          line
+          isResolved
+          isOutdated
+          comments(first: 100) {
+            pageInfo {
+              hasNextPage
+            }
+            nodes {
+              body
+              createdAt
+              state
+              author {
+                login
+              }
+              pullRequestReview {
+                commit {
+                  oid
+                }
+              }
+            }
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}

--- a/gh-helper/review_monitor.go
+++ b/gh-helper/review_monitor.go
@@ -35,11 +35,11 @@ const (
 
 // ReviewItem represents an actionable item from a review
 type ReviewItem struct {
-	ReviewID    string          `json:"reviewId"`
-	Author      string          `json:"author"`
-	CreatedAt   string          `json:"createdAt"`
-	Severity    ReviewSeverity  `json:"severity"`
-	BodyPreview string          `json:"bodyPreview"`
+	ReviewID    string         `json:"reviewId"`
+	Author      string         `json:"author"`
+	CreatedAt   string         `json:"createdAt"`
+	Severity    ReviewSeverity `json:"severity"`
+	BodyPreview string         `json:"bodyPreview"`
 }
 
 // NewReviewMonitor creates a new review monitor
@@ -89,8 +89,8 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
 				PullRequest struct {
 					Reviews struct {
 						Nodes []struct {
-							ID        string `json:"id"`
-							Author    struct {
+							ID     string `json:"id"`
+							Author struct {
 								Login string `json:"login"`
 							} `json:"author"`
 							CreatedAt string `json:"createdAt"`
@@ -115,7 +115,7 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
 
 		// Analyze review body for actionable items
 		severity := m.detectSeverity(review.Body)
-		
+
 		items = append(items, ReviewItem{
 			ReviewID:    review.ID,
 			Author:      review.Author.Login,
@@ -140,51 +140,48 @@ func (m *ReviewMonitor) detectSeverity(body string) ReviewSeverity {
 	return SeverityInfo
 }
 
-
-
 // truncateBody creates a preview of the review body
 func (m *ReviewMonitor) truncateBody(body string, maxLen int) string {
 	// Remove excessive whitespace
 	body = strings.TrimSpace(body)
 	body = strings.ReplaceAll(body, "\n\n\n", "\n\n")
-	
+
 	if len(body) <= maxLen {
 		return body
 	}
-	
+
 	// Try to break at word boundary
 	truncated := body[:maxLen]
 	lastSpace := strings.LastIndex(truncated, " ")
 	if lastSpace > maxLen*3/4 {
 		truncated = truncated[:lastSpace]
 	}
-	
+
 	return truncated + "..."
 }
-
 
 // FormatReviewItems creates a formatted output of review items
 func FormatReviewItems(items []ReviewItem) string {
 	if len(items) == 0 {
 		return "No actionable review items found"
 	}
-	
+
 	var output strings.Builder
-	output.WriteString(fmt.Sprintf("📋 Found %d actionable review item(s):\n\n", len(items)))
-	
+	fmt.Fprintf(&output, "📋 Found %d actionable review item(s):\n\n", len(items))
+
 	// Group by severity
 	bySeverity := make(map[ReviewSeverity][]ReviewItem)
 	for _, item := range items {
 		bySeverity[item.Severity] = append(bySeverity[item.Severity], item)
 	}
-	
+
 	// Output in priority order (only 3 levels now)
 	for _, severity := range []ReviewSeverity{SeverityCritical, SeverityHigh, SeverityInfo} {
 		items, ok := bySeverity[severity]
 		if !ok || len(items) == 0 {
 			continue
 		}
-		
+
 		severityIcon := "ℹ️"
 		switch severity {
 		case SeverityCritical:
@@ -192,10 +189,10 @@ func FormatReviewItems(items []ReviewItem) string {
 		case SeverityHigh:
 			severityIcon = "⚠️"
 		}
-		
-		output.WriteString(fmt.Sprintf("%s %s Priority:\n", severityIcon, severity))
+
+		fmt.Fprintf(&output, "%s %s Priority:\n", severityIcon, severity)
 		for _, item := range items {
-			output.WriteString(fmt.Sprintf("  • %s by %s at %s\n", item.ReviewID, item.Author, item.CreatedAt))
+			fmt.Fprintf(&output, "  • %s by %s at %s\n", item.ReviewID, item.Author, item.CreatedAt)
 			if item.BodyPreview != "" {
 				// Indent body preview for readability
 				previewLines := strings.Split(item.BodyPreview, "\n")
@@ -211,6 +208,6 @@ func FormatReviewItems(items []ReviewItem) string {
 			output.WriteString("\n")
 		}
 	}
-	
+
 	return output.String()
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+golangci-lint = "latest"

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,2 @@
 [tools]
-golangci-lint = "latest"
+golangci-lint = "2.12.1"


### PR DESCRIPTION
## Summary
- Add `gh-helper reviews bot-status` to report Copilot and Gemini review status for the current PR head.
- Avoid duplicate `/gemini review` requests when Gemini has already reviewed the current PR head.
- Add repo-local `mise.toml` and run golangci-lint through `mise install`/`mise exec` from `gh-helper`.
- Fix latest golangci-lint staticcheck findings in review monitor formatting.

## Why
The review-loop skill depends on current-head evidence from bot reviewers. This makes that state available as structured output and reduces repeated bot review requests for the same commit.

## Validation
- `make check`