### PR TITLE
Add API usage telemetry to gh-helper commands

### DIFF
--- a/gh-helper/README.md
+++ b/gh-helper/README.md
@@ -20,6 +20,9 @@ gh-helper reviews fetch [PR] --json | jq '.reviewThreads.needingReply[]'
 
 # Include command-local REST/GraphQL usage telemetry
 gh-helper reviews bot-status [PR] --json --api-usage
+
+# Trace every GitHub API request to stderr while keeping stdout machine-readable
+gh-helper threads submit pr/306 --json --api-usage-trace
 ```
 
 ## Design Philosophy
@@ -85,6 +88,7 @@ stderr after the command completes.
 gh-helper reviews fetch 306 --unresolved-only --api-usage
 gh-helper reviews bot-status 306 --json --api-usage
 gh-helper threads reply THREAD --resolve --message "Fixed" --api-usage
+gh-helper threads submit pr/306 --api-usage-trace
 ```
 
 The telemetry includes the selected backend classification (`rest`, `graphql`,
@@ -96,6 +100,13 @@ queries where `rateLimit` cannot be injected, cost is only estimated when
 sequential response headers expose an in-command `used` delta; otherwise the
 request is counted as cost-unavailable while still reporting the latest
 `limit`, `remaining`, `used`, `resetAt`, and `resetInSeconds` values.
+
+Use `--api-usage-trace` when investigating command-level API consumption. It
+prints one stderr line for every GitHub REST or GraphQL request, including
+request order, operation type/name for GraphQL, REST method/path, HTTP status,
+cost source, response cost or estimated cost when available, node count, and the
+latest rate-limit budget. This flag is intentionally stderr-only so JSON/YAML
+stdout stays pipeable.
 
 Even without `--api-usage`, gh-helper watches GitHub response rate-limit headers
 and prints a stderr warning when `x-ratelimit-used / x-ratelimit-limit` reaches

--- a/gh-helper/README.md
+++ b/gh-helper/README.md
@@ -80,9 +80,10 @@ gh-helper reviews analyze 306 --json | jq '.summary.critical'
 ### API Usage Telemetry
 
 All subcommands accept `--api-usage` to expose command-local GitHub API usage.
-For structured output, `apiUsage` is added to the encoded object. For commands
-that primarily print human-readable progress, a concise summary is printed to
-stderr after the command completes.
+For structured output, the encoded object is wrapped as `data` plus `apiUsage`
+so the shape is consistent across commands. For commands that primarily print
+human-readable progress, a concise summary is printed to stderr after the
+command completes.
 
 ```bash
 gh-helper reviews fetch 306 --unresolved-only --api-usage

--- a/gh-helper/README.md
+++ b/gh-helper/README.md
@@ -17,6 +17,9 @@ gh-helper threads reply <THREAD_ID> --message "Fixed in commit abc123"
 
 # JSON output for programmatic processing
 gh-helper reviews fetch [PR] --json | jq '.reviewThreads.needingReply[]'
+
+# Include command-local REST/GraphQL usage telemetry
+gh-helper reviews bot-status [PR] --json --api-usage
 ```
 
 ## Design Philosophy
@@ -70,6 +73,34 @@ gh-helper reviews fetch 306 | gojq --yaml-input '.reviewThreads.needsReplyCount'
 # JSON for traditional jq processing
 gh-helper reviews analyze 306 --json | jq '.summary.critical'
 ```
+
+### API Usage Telemetry
+
+All subcommands accept `--api-usage` to expose command-local GitHub API usage.
+For structured output, `apiUsage` is added to the encoded object. For commands
+that primarily print human-readable progress, a concise summary is printed to
+stderr after the command completes.
+
+```bash
+gh-helper reviews fetch 306 --unresolved-only --api-usage
+gh-helper reviews bot-status 306 --json --api-usage
+gh-helper threads reply THREAD --resolve --message "Fixed" --api-usage
+```
+
+The telemetry includes the selected backend classification (`rest`, `graphql`,
+`mixed`, or `none`), observed REST and GraphQL request counts, GraphQL
+`rateLimit.cost` and `rateLimit.nodeCount` from query responses when available,
+and core/GraphQL rate-limit budget from API response headers. gh-helper does not
+call the separate `/rate_limit` endpoint for this flag. For GraphQL mutations or
+queries where `rateLimit` cannot be injected, cost is only estimated when
+sequential response headers expose an in-command `used` delta; otherwise the
+request is counted as cost-unavailable while still reporting the latest
+`limit`, `remaining`, `used`, `resetAt`, and `resetInSeconds` values.
+
+Even without `--api-usage`, gh-helper watches GitHub response rate-limit headers
+and prints a stderr warning when `x-ratelimit-used / x-ratelimit-limit` reaches
+50%. Tune this with `--rate-limit-warning-threshold`; set it to `0` to disable
+the warning.
 
 ## Commands Overview
 

--- a/gh-helper/api_usage.go
+++ b/gh-helper/api_usage.go
@@ -81,7 +81,7 @@ type apiUsageRecorder struct {
 	lastGraphQLUsed *int
 
 	warningThreshold float64
-	warningWritten   bool
+	warningWritten   map[string]bool
 	warningWriter    io.Writer
 	trace            bool
 	traceWriter      io.Writer
@@ -117,11 +117,6 @@ func attachAPIUsageToOutput(cmd *cobra.Command, data interface{}) (interface{}, 
 	}
 
 	report := commandAPIUsage.Finish()
-
-	if dataMap, ok := data.(map[string]interface{}); ok {
-		dataMap["apiUsage"] = report
-		return dataMap, true
-	}
 
 	return map[string]interface{}{
 		"data":     data,
@@ -165,7 +160,7 @@ func (r *apiUsageRecorder) Reset(enabled bool) {
 	r.warnings = nil
 	r.lastGraphQLUsed = nil
 	r.warningThreshold = 0
-	r.warningWritten = false
+	r.warningWritten = nil
 	r.warningWriter = os.Stderr
 	r.trace = false
 	r.traceWriter = os.Stderr
@@ -209,9 +204,12 @@ func (r *apiUsageRecorder) RecordGraphQLResponse(headers http.Header, body []byt
 	if !r.shouldTrackLocked() {
 		return
 	}
-	r.observed.GraphQLRequests++
 	previousUsed := r.lastGraphQLUsed
 	r.updateAfterFromHeaders("graphql", headers)
+	if !r.enabled && !r.trace {
+		return
+	}
+	r.observed.GraphQLRequests++
 	if rateLimit, ok := graphQLRateLimitFromResponse(body); ok {
 		r.observed.GraphQLCost += rateLimit.Cost
 		r.observed.GraphQLCostKnownRequests++
@@ -245,8 +243,11 @@ func (r *apiUsageRecorder) RecordRESTResponse(headers http.Header, trace restReq
 	if !r.shouldTrackLocked() {
 		return
 	}
-	r.observed.RESTRequests++
 	r.updateAfterFromHeaders("core", headers)
+	if !r.enabled && !r.trace {
+		return
+	}
+	r.observed.RESTRequests++
 	r.writeRESTTraceLocked(trace)
 }
 
@@ -360,7 +361,10 @@ func (r *apiUsageRecorder) updateAfterFromGraphQLRateLimit(rateLimit graphQLRate
 }
 
 func (r *apiUsageRecorder) maybeWarnRateLimitLocked(resource string, rateLimit rateLimitResource) {
-	if r.warningWritten || r.warningThreshold <= 0 || rateLimit.Limit <= 0 {
+	if r.warningThreshold <= 0 || rateLimit.Limit <= 0 {
+		return
+	}
+	if r.warningWritten != nil && r.warningWritten[resource] {
 		return
 	}
 	usedRatio := float64(rateLimit.Used) / float64(rateLimit.Limit)
@@ -390,7 +394,10 @@ func (r *apiUsageRecorder) maybeWarnRateLimitLocked(resource string, rateLimit r
 		resetAt,
 		resetIn,
 	)
-	r.warningWritten = true
+	if r.warningWritten == nil {
+		r.warningWritten = map[string]bool{}
+	}
+	r.warningWritten[resource] = true
 }
 
 func (r *apiUsageRecorder) writeGraphQLTraceLocked(trace graphQLRequestTrace, costSource string, rateLimit *graphQLRateLimitTelemetry, estimatedCost *int) {

--- a/gh-helper/api_usage.go
+++ b/gh-helper/api_usage.go
@@ -63,11 +63,15 @@ type rateLimitSnapshot struct {
 }
 
 type rateLimitResource struct {
-	Seen      bool
-	Limit     int
-	Remaining int
-	Used      int
-	Reset     int64
+	Seen          bool
+	Limit         int
+	LimitSeen     bool
+	Remaining     int
+	RemainingSeen bool
+	Used          int
+	UsedSeen      bool
+	Reset         int64
+	ResetSeen     bool
 }
 
 type apiUsageRecorder struct {
@@ -329,15 +333,22 @@ func (r *apiUsageRecorder) updateAfterFromHeaders(resource string, headers http.
 	target.Seen = target.Seen || limitOK || remainingOK || usedOK || resetOK
 	if limitOK {
 		target.Limit = limit
+		target.LimitSeen = true
 	}
 	if remainingOK {
 		target.Remaining = remaining
+		target.RemainingSeen = true
 	}
 	if usedOK {
 		target.Used = used
+		target.UsedSeen = true
+	} else if limitOK && remainingOK {
+		target.Used = limit - remaining
+		target.UsedSeen = true
 	}
 	if resetOK {
 		target.Reset = reset
+		target.ResetSeen = true
 	}
 	r.maybeWarnRateLimitLocked(resource, *target)
 }
@@ -352,19 +363,23 @@ func (r *apiUsageRecorder) updateAfterFromGraphQLRateLimit(rateLimit graphQLRate
 	target.Seen = true
 	if rateLimit.Limit != 0 {
 		target.Limit = rateLimit.Limit
+		target.LimitSeen = true
 	}
 	target.Remaining = rateLimit.Remaining
+	target.RemainingSeen = true
 	target.Used = rateLimit.Used
+	target.UsedSeen = true
 	if rateLimit.ResetAt != "" {
 		if resetAt, err := time.Parse(time.RFC3339, rateLimit.ResetAt); err == nil {
 			target.Reset = resetAt.Unix()
+			target.ResetSeen = true
 		}
 	}
 	r.maybeWarnRateLimitLocked("graphql", *target)
 }
 
 func (r *apiUsageRecorder) maybeWarnRateLimitLocked(resource string, rateLimit rateLimitResource) {
-	if r.warningThreshold <= 0 || rateLimit.Limit <= 0 {
+	if r.warningThreshold <= 0 || !rateLimit.LimitSeen || !rateLimit.UsedSeen || rateLimit.Limit <= 0 {
 		return
 	}
 	if r.warningWritten != nil && r.warningWritten[resource] {
@@ -377,7 +392,7 @@ func (r *apiUsageRecorder) maybeWarnRateLimitLocked(resource string, rateLimit r
 
 	resetAt := "unknown"
 	resetIn := ""
-	if rateLimit.Reset != 0 {
+	if rateLimit.ResetSeen {
 		resetAtTime := time.Unix(rateLimit.Reset, 0).UTC()
 		resetAt = resetAtTime.Format(time.RFC3339)
 		resetIn = fmt.Sprintf(" in %s", formatResetIn(time.Until(resetAtTime)))
@@ -392,7 +407,7 @@ func (r *apiUsageRecorder) maybeWarnRateLimitLocked(resource string, rateLimit r
 		usedRatio*100,
 		rateLimit.Used,
 		rateLimit.Limit,
-		rateLimit.Remaining,
+		rateLimitRemainingForWarning(rateLimit),
 		resetAt,
 		resetIn,
 	)
@@ -489,13 +504,15 @@ func appendRateLimitHeaderTraceParts(parts []string, rateLimit *rateLimitResourc
 	if rateLimit == nil || !rateLimit.Seen {
 		return parts
 	}
-	if rateLimit.Limit != 0 {
+	if rateLimit.UsedSeen && rateLimit.LimitSeen {
 		parts = append(parts, fmt.Sprintf("used=%d/%d", rateLimit.Used, rateLimit.Limit))
-	} else {
+	} else if rateLimit.UsedSeen {
 		parts = append(parts, fmt.Sprintf("used=%d", rateLimit.Used))
 	}
-	parts = append(parts, fmt.Sprintf("remaining=%d", rateLimit.Remaining))
-	if rateLimit.Reset != 0 {
+	if rateLimit.RemainingSeen {
+		parts = append(parts, fmt.Sprintf("remaining=%d", rateLimit.Remaining))
+	}
+	if rateLimit.ResetSeen {
 		resetAt := time.Unix(rateLimit.Reset, 0).UTC()
 		parts = append(parts, "resetAt="+resetAt.Format(time.RFC3339), "resetIn="+formatResetIn(time.Until(resetAt)))
 	}
@@ -543,17 +560,28 @@ func buildRateLimitResourceReport(after *rateLimitResource) *APIUsageRateLimitRe
 	}
 
 	report := &APIUsageRateLimitResource{}
-	report.Remaining = apiUsageIntPtr(after.Remaining)
-	report.Used = apiUsageIntPtr(after.Used)
-	if after.Limit != 0 {
+	if after.RemainingSeen {
+		report.Remaining = apiUsageIntPtr(after.Remaining)
+	}
+	if after.UsedSeen {
+		report.Used = apiUsageIntPtr(after.Used)
+	}
+	if after.LimitSeen {
 		report.Limit = apiUsageIntPtr(after.Limit)
 	}
-	if after.Reset != 0 {
+	if after.ResetSeen {
 		resetAt := time.Unix(after.Reset, 0).UTC()
 		report.ResetAt = resetAt.Format(time.RFC3339)
 		report.ResetInSeconds = apiUsageInt64Ptr(maxDurationSeconds(time.Until(resetAt)))
 	}
 	return report
+}
+
+func rateLimitRemainingForWarning(rateLimit rateLimitResource) int {
+	if rateLimit.RemainingSeen {
+		return rateLimit.Remaining
+	}
+	return rateLimit.Limit - rateLimit.Used
 }
 
 func apiUsageIntPtr(value int) *int {

--- a/gh-helper/api_usage.go
+++ b/gh-helper/api_usage.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -14,10 +15,10 @@ import (
 )
 
 type APIUsageReport struct {
-	Backend   string            `json:"backend"`
-	Observed  APIUsageObserved  `json:"observed"`
-	RateLimit APIUsageRateLimit `json:"rateLimit,omitempty"`
-	Warnings  []string          `json:"warnings,omitempty"`
+	Backend   string             `json:"backend"`
+	Observed  APIUsageObserved   `json:"observed"`
+	RateLimit *APIUsageRateLimit `json:"rateLimit,omitempty"`
+	Warnings  []string           `json:"warnings,omitempty"`
 }
 
 type APIUsageObserved struct {
@@ -31,8 +32,8 @@ type APIUsageObserved struct {
 }
 
 type APIUsageRateLimit struct {
-	Core    APIUsageRateLimitResource `json:"core,omitempty"`
-	GraphQL APIUsageRateLimitResource `json:"graphql,omitempty"`
+	Core    *APIUsageRateLimitResource `json:"core,omitempty"`
+	GraphQL *APIUsageRateLimitResource `json:"graphql,omitempty"`
 }
 
 type APIUsageRateLimitResource struct {
@@ -69,20 +70,23 @@ type apiUsageRecorder struct {
 
 	warningThreshold float64
 	warningWritten   bool
+	warningWriter    io.Writer
 	structuredOutput bool
 }
 
 var commandAPIUsage = &apiUsageRecorder{}
 
-func startAPIUsageForCommand(_ *cobra.Command, _ []string) {
+func startAPIUsageForCommand(cmd *cobra.Command, _ []string) {
 	if !apiUsage {
 		commandAPIUsage.Reset(false)
 		commandAPIUsage.SetWarningThreshold(rateLimitWarningThreshold)
+		commandAPIUsage.SetWarningWriter(cmd.ErrOrStderr())
 		return
 	}
 
 	commandAPIUsage.Reset(true)
 	commandAPIUsage.SetWarningThreshold(rateLimitWarningThreshold)
+	commandAPIUsage.SetWarningWriter(cmd.ErrOrStderr())
 }
 
 func printAPIUsageForTextCommand(cmd *cobra.Command, _ []string) {
@@ -95,31 +99,26 @@ func printAPIUsageForTextCommand(cmd *cobra.Command, _ []string) {
 	}
 }
 
-func apiUsageEnabledForCommand(cmd *cobra.Command) bool {
-	if cmd == nil {
-		return false
-	}
-	enabled, err := cmd.Root().PersistentFlags().GetBool("api-usage")
-	return err == nil && enabled
+func apiUsageEnabledForCommand(_ *cobra.Command) bool {
+	return apiUsage
 }
 
-func attachAPIUsageToOutput(cmd *cobra.Command, data interface{}) interface{} {
+func attachAPIUsageToOutput(cmd *cobra.Command, data interface{}) (interface{}, bool) {
 	if !apiUsageEnabledForCommand(cmd) {
-		return data
+		return data, false
 	}
 
 	report := commandAPIUsage.Finish()
-	commandAPIUsage.MarkStructuredOutputWritten()
 
 	if dataMap, ok := data.(map[string]interface{}); ok {
 		dataMap["apiUsage"] = report
-		return dataMap
+		return dataMap, true
 	}
 
 	return map[string]interface{}{
 		"data":     data,
 		"apiUsage": report,
-	}
+	}, true
 }
 
 func formatAPIUsageSummary(report *APIUsageReport) string {
@@ -134,10 +133,10 @@ func formatAPIUsageSummary(report *APIUsageReport) string {
 	if report.Observed.GraphQLCost > 0 {
 		parts = append(parts, fmt.Sprintf("graphqlCost=%d", report.Observed.GraphQLCost))
 	}
-	if report.RateLimit.Core.Remaining != nil {
+	if report.RateLimit != nil && report.RateLimit.Core != nil && report.RateLimit.Core.Remaining != nil {
 		parts = append(parts, fmt.Sprintf("coreRemaining=%d", *report.RateLimit.Core.Remaining))
 	}
-	if report.RateLimit.GraphQL.Remaining != nil {
+	if report.RateLimit != nil && report.RateLimit.GraphQL != nil && report.RateLimit.GraphQL.Remaining != nil {
 		parts = append(parts, fmt.Sprintf("graphqlRemaining=%d", *report.RateLimit.GraphQL.Remaining))
 	}
 	if len(report.Warnings) > 0 {
@@ -159,6 +158,7 @@ func (r *apiUsageRecorder) Reset(enabled bool) {
 	r.lastGraphQLUsed = nil
 	r.warningThreshold = 0
 	r.warningWritten = false
+	r.warningWriter = os.Stderr
 	r.structuredOutput = false
 }
 
@@ -167,6 +167,17 @@ func (r *apiUsageRecorder) SetWarningThreshold(threshold float64) {
 	defer r.mu.Unlock()
 
 	r.warningThreshold = threshold
+}
+
+func (r *apiUsageRecorder) SetWarningWriter(writer io.Writer) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if writer == nil {
+		r.warningWriter = os.Stderr
+		return
+	}
+	r.warningWriter = writer
 }
 
 func (r *apiUsageRecorder) RecordGraphQLResponse(headers http.Header, body []byte) {
@@ -336,8 +347,12 @@ func (r *apiUsageRecorder) maybeWarnRateLimitLocked(resource string, rateLimit r
 		resetAt = resetAtTime.Format(time.RFC3339)
 		resetIn = fmt.Sprintf(" in %s", formatResetIn(time.Until(resetAtTime)))
 	}
+	writer := r.warningWriter
+	if writer == nil {
+		writer = os.Stderr
+	}
 	_, _ = fmt.Fprintf(
-		os.Stderr,
+		writer,
 		"warning: GitHub %s API rate limit is %.0f%% used (%d/%d used, %d remaining, resets at %s%s)\n",
 		resource,
 		usedRatio*100,
@@ -363,10 +378,15 @@ func observedBackend(observed APIUsageObserved) string {
 	}
 }
 
-func buildRateLimitReport(after *rateLimitSnapshot) APIUsageRateLimit {
-	return APIUsageRateLimit{
-		Core:    buildRateLimitResourceReport(resourceFromSnapshot(after, "core")),
-		GraphQL: buildRateLimitResourceReport(resourceFromSnapshot(after, "graphql")),
+func buildRateLimitReport(after *rateLimitSnapshot) *APIUsageRateLimit {
+	core := buildRateLimitResourceReport(resourceFromSnapshot(after, "core"))
+	graphQL := buildRateLimitResourceReport(resourceFromSnapshot(after, "graphql"))
+	if core == nil && graphQL == nil {
+		return nil
+	}
+	return &APIUsageRateLimit{
+		Core:    core,
+		GraphQL: graphQL,
 	}
 }
 
@@ -380,12 +400,12 @@ func resourceFromSnapshot(snapshot *rateLimitSnapshot, resource string) *rateLim
 	return &snapshot.Core
 }
 
-func buildRateLimitResourceReport(after *rateLimitResource) APIUsageRateLimitResource {
-	report := APIUsageRateLimitResource{}
+func buildRateLimitResourceReport(after *rateLimitResource) *APIUsageRateLimitResource {
 	if after == nil || !after.Seen {
-		return report
+		return nil
 	}
 
+	report := &APIUsageRateLimitResource{}
 	report.Remaining = apiUsageIntPtr(after.Remaining)
 	report.Used = apiUsageIntPtr(after.Used)
 	if after.Limit != 0 {
@@ -427,7 +447,6 @@ func formatResetIn(duration time.Duration) string {
 	if duration < time.Hour {
 		return duration.String()
 	}
-	duration = duration.Round(time.Minute)
 	return duration.String()
 }
 

--- a/gh-helper/api_usage.go
+++ b/gh-helper/api_usage.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"log/slog"
@@ -210,14 +211,16 @@ func (r *apiUsageRecorder) RecordGraphQLResponse(headers http.Header, body []byt
 		return
 	}
 	r.observed.GraphQLRequests++
-	if rateLimit, ok := graphQLRateLimitFromResponse(body); ok {
-		r.observed.GraphQLCost += rateLimit.Cost
-		r.observed.GraphQLCostKnownRequests++
-		r.observed.GraphQLNodeCount += rateLimit.NodeCount
-		r.updateAfterFromGraphQLRateLimit(rateLimit)
-		r.lastGraphQLUsed = apiUsageIntPtr(rateLimit.Used)
-		r.writeGraphQLTraceLocked(trace, "response", &rateLimit, nil)
-		return
+	if bytes.Contains(body, []byte(graphQLRateLimitAlias)) {
+		if rateLimit, ok := graphQLRateLimitFromResponse(body); ok {
+			r.observed.GraphQLCost += rateLimit.Cost
+			r.observed.GraphQLCostKnownRequests++
+			r.observed.GraphQLNodeCount += rateLimit.NodeCount
+			r.updateAfterFromGraphQLRateLimit(rateLimit)
+			r.lastGraphQLUsed = apiUsageIntPtr(rateLimit.Used)
+			r.writeGraphQLTraceLocked(trace, "response", &rateLimit, nil)
+			return
+		}
 	}
 	if used, ok := parseHeaderInt(headers, "x-ratelimit-used"); ok {
 		if previousUsed != nil && used > *previousUsed {
@@ -383,9 +386,8 @@ func (r *apiUsageRecorder) maybeWarnRateLimitLocked(resource string, rateLimit r
 	if writer == nil {
 		writer = os.Stderr
 	}
-	_, _ = fmt.Fprintf(
-		writer,
-		"warning: GitHub %s API rate limit is %.0f%% used (%d/%d used, %d remaining, resets at %s%s)\n",
+	warningMessage := fmt.Sprintf(
+		"GitHub %s API rate limit is %.0f%% used (%d/%d used, %d remaining, resets at %s%s)",
 		resource,
 		usedRatio*100,
 		rateLimit.Used,
@@ -394,6 +396,10 @@ func (r *apiUsageRecorder) maybeWarnRateLimitLocked(resource string, rateLimit r
 		resetAt,
 		resetIn,
 	)
+	if r.enabled {
+		r.warnings = append(r.warnings, warningMessage)
+	}
+	_, _ = fmt.Fprintln(writer, "warning: "+warningMessage)
 	if r.warningWritten == nil {
 		r.warningWritten = map[string]bool{}
 	}

--- a/gh-helper/api_usage.go
+++ b/gh-helper/api_usage.go
@@ -1,0 +1,456 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+type APIUsageReport struct {
+	Backend   string            `json:"backend"`
+	Observed  APIUsageObserved  `json:"observed"`
+	RateLimit APIUsageRateLimit `json:"rateLimit,omitempty"`
+	Warnings  []string          `json:"warnings,omitempty"`
+}
+
+type APIUsageObserved struct {
+	RESTRequests                   int `json:"restRequests,omitempty"`
+	GraphQLRequests                int `json:"graphqlRequests,omitempty"`
+	GraphQLCost                    int `json:"graphqlCost,omitempty"`
+	GraphQLCostKnownRequests       int `json:"graphqlCostKnownRequests,omitempty"`
+	GraphQLCostEstimatedRequests   int `json:"graphqlCostEstimatedRequests,omitempty"`
+	GraphQLCostUnavailableRequests int `json:"graphqlCostUnavailableRequests,omitempty"`
+	GraphQLNodeCount               int `json:"graphqlNodeCount,omitempty"`
+}
+
+type APIUsageRateLimit struct {
+	Core    APIUsageRateLimitResource `json:"core,omitempty"`
+	GraphQL APIUsageRateLimitResource `json:"graphql,omitempty"`
+}
+
+type APIUsageRateLimitResource struct {
+	Remaining      *int   `json:"remaining,omitempty"`
+	Used           *int   `json:"used,omitempty"`
+	Limit          *int   `json:"limit,omitempty"`
+	ResetAt        string `json:"resetAt,omitempty"`
+	ResetInSeconds *int64 `json:"resetInSeconds,omitempty"`
+}
+
+type rateLimitSnapshot struct {
+	Core    rateLimitResource
+	GraphQL rateLimitResource
+}
+
+type rateLimitResource struct {
+	Seen      bool
+	Limit     int
+	Remaining int
+	Used      int
+	Reset     int64
+}
+
+type apiUsageRecorder struct {
+	mu       sync.Mutex
+	enabled  bool
+	finished bool
+	report   *APIUsageReport
+
+	observed        APIUsageObserved
+	after           *rateLimitSnapshot
+	warnings        []string
+	lastGraphQLUsed *int
+
+	warningThreshold float64
+	warningWritten   bool
+	structuredOutput bool
+}
+
+var commandAPIUsage = &apiUsageRecorder{}
+
+func startAPIUsageForCommand(_ *cobra.Command, _ []string) {
+	if !apiUsage {
+		commandAPIUsage.Reset(false)
+		commandAPIUsage.SetWarningThreshold(rateLimitWarningThreshold)
+		return
+	}
+
+	commandAPIUsage.Reset(true)
+	commandAPIUsage.SetWarningThreshold(rateLimitWarningThreshold)
+}
+
+func printAPIUsageForTextCommand(cmd *cobra.Command, _ []string) {
+	if !apiUsage || commandAPIUsage.StructuredOutputWritten() {
+		return
+	}
+	report := commandAPIUsage.Finish()
+	if _, err := fmt.Fprintln(cmd.ErrOrStderr(), formatAPIUsageSummary(report)); err != nil {
+		slog.Warn("failed to write api usage summary", "error", err)
+	}
+}
+
+func apiUsageEnabledForCommand(cmd *cobra.Command) bool {
+	if cmd == nil {
+		return false
+	}
+	enabled, err := cmd.Root().PersistentFlags().GetBool("api-usage")
+	return err == nil && enabled
+}
+
+func attachAPIUsageToOutput(cmd *cobra.Command, data interface{}) interface{} {
+	if !apiUsageEnabledForCommand(cmd) {
+		return data
+	}
+
+	report := commandAPIUsage.Finish()
+	commandAPIUsage.MarkStructuredOutputWritten()
+
+	if dataMap, ok := data.(map[string]interface{}); ok {
+		dataMap["apiUsage"] = report
+		return dataMap
+	}
+
+	return map[string]interface{}{
+		"data":     data,
+		"apiUsage": report,
+	}
+}
+
+func formatAPIUsageSummary(report *APIUsageReport) string {
+	if report == nil {
+		return "apiUsage: unavailable"
+	}
+	parts := []string{
+		fmt.Sprintf("backend=%s", report.Backend),
+		fmt.Sprintf("restRequests=%d", report.Observed.RESTRequests),
+		fmt.Sprintf("graphqlRequests=%d", report.Observed.GraphQLRequests),
+	}
+	if report.Observed.GraphQLCost > 0 {
+		parts = append(parts, fmt.Sprintf("graphqlCost=%d", report.Observed.GraphQLCost))
+	}
+	if report.RateLimit.Core.Remaining != nil {
+		parts = append(parts, fmt.Sprintf("coreRemaining=%d", *report.RateLimit.Core.Remaining))
+	}
+	if report.RateLimit.GraphQL.Remaining != nil {
+		parts = append(parts, fmt.Sprintf("graphqlRemaining=%d", *report.RateLimit.GraphQL.Remaining))
+	}
+	if len(report.Warnings) > 0 {
+		parts = append(parts, fmt.Sprintf("warnings=%d", len(report.Warnings)))
+	}
+	return "apiUsage: " + strings.Join(parts, " ")
+}
+
+func (r *apiUsageRecorder) Reset(enabled bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.enabled = enabled
+	r.finished = false
+	r.report = nil
+	r.observed = APIUsageObserved{}
+	r.after = nil
+	r.warnings = nil
+	r.lastGraphQLUsed = nil
+	r.warningThreshold = 0
+	r.warningWritten = false
+	r.structuredOutput = false
+}
+
+func (r *apiUsageRecorder) SetWarningThreshold(threshold float64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.warningThreshold = threshold
+}
+
+func (r *apiUsageRecorder) RecordGraphQLResponse(headers http.Header, body []byte) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if !r.shouldTrackLocked() {
+		return
+	}
+	r.observed.GraphQLRequests++
+	previousUsed := r.lastGraphQLUsed
+	r.updateAfterFromHeaders("graphql", headers)
+	if rateLimit, ok := graphQLRateLimitFromResponse(body); ok {
+		r.observed.GraphQLCost += rateLimit.Cost
+		r.observed.GraphQLCostKnownRequests++
+		r.observed.GraphQLNodeCount += rateLimit.NodeCount
+		r.updateAfterFromGraphQLRateLimit(rateLimit)
+		r.lastGraphQLUsed = apiUsageIntPtr(rateLimit.Used)
+		return
+	}
+	if used, ok := parseHeaderInt(headers, "x-ratelimit-used"); ok {
+		if previousUsed != nil && used > *previousUsed {
+			r.observed.GraphQLCost += used - *previousUsed
+			r.observed.GraphQLCostEstimatedRequests++
+		} else {
+			r.observed.GraphQLCostUnavailableRequests++
+		}
+		r.lastGraphQLUsed = apiUsageIntPtr(used)
+		return
+	}
+	r.observed.GraphQLCostUnavailableRequests++
+}
+
+func (r *apiUsageRecorder) RecordRESTResponse(headers http.Header) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if !r.shouldTrackLocked() {
+		return
+	}
+	r.observed.RESTRequests++
+	r.updateAfterFromHeaders("core", headers)
+}
+
+func (r *apiUsageRecorder) AddWarning(warning string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if !r.enabled {
+		return
+	}
+	r.warnings = append(r.warnings, warning)
+}
+
+func (r *apiUsageRecorder) StructuredOutputWritten() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.structuredOutput
+}
+
+func (r *apiUsageRecorder) MarkStructuredOutputWritten() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.enabled {
+		r.structuredOutput = true
+	}
+}
+
+func (r *apiUsageRecorder) shouldTrackLocked() bool {
+	return r.enabled || r.warningThreshold > 0
+}
+
+func (r *apiUsageRecorder) Finish() *APIUsageReport {
+	r.mu.Lock()
+	if r.finished {
+		report := r.report
+		r.mu.Unlock()
+		return report
+	}
+	defer r.mu.Unlock()
+
+	report := r.buildReportLocked()
+	r.report = report
+	r.finished = true
+	return report
+}
+
+func (r *apiUsageRecorder) buildReportLocked() *APIUsageReport {
+	observed := r.observed
+
+	return &APIUsageReport{
+		Backend:   observedBackend(observed),
+		Observed:  observed,
+		RateLimit: buildRateLimitReport(r.after),
+		Warnings:  append([]string(nil), r.warnings...),
+	}
+}
+
+func (r *apiUsageRecorder) updateAfterFromHeaders(resource string, headers http.Header) {
+	snapshot := r.after
+	if snapshot == nil {
+		snapshot = &rateLimitSnapshot{}
+		r.after = snapshot
+	}
+
+	limit, limitOK := parseHeaderInt(headers, "x-ratelimit-limit")
+	remaining, remainingOK := parseHeaderInt(headers, "x-ratelimit-remaining")
+	used, usedOK := parseHeaderInt(headers, "x-ratelimit-used")
+	reset, resetOK := parseHeaderInt64(headers, "x-ratelimit-reset")
+
+	target := &snapshot.Core
+	if resource == "graphql" {
+		target = &snapshot.GraphQL
+	}
+	target.Seen = target.Seen || limitOK || remainingOK || usedOK || resetOK
+	if limitOK {
+		target.Limit = limit
+	}
+	if remainingOK {
+		target.Remaining = remaining
+	}
+	if usedOK {
+		target.Used = used
+	}
+	if resetOK {
+		target.Reset = reset
+	}
+	r.maybeWarnRateLimitLocked(resource, *target)
+}
+
+func (r *apiUsageRecorder) updateAfterFromGraphQLRateLimit(rateLimit graphQLRateLimitTelemetry) {
+	snapshot := r.after
+	if snapshot == nil {
+		snapshot = &rateLimitSnapshot{}
+		r.after = snapshot
+	}
+	target := &snapshot.GraphQL
+	target.Seen = true
+	if rateLimit.Limit != 0 {
+		target.Limit = rateLimit.Limit
+	}
+	target.Remaining = rateLimit.Remaining
+	target.Used = rateLimit.Used
+	if rateLimit.ResetAt != "" {
+		if resetAt, err := time.Parse(time.RFC3339, rateLimit.ResetAt); err == nil {
+			target.Reset = resetAt.Unix()
+		}
+	}
+	r.maybeWarnRateLimitLocked("graphql", *target)
+}
+
+func (r *apiUsageRecorder) maybeWarnRateLimitLocked(resource string, rateLimit rateLimitResource) {
+	if r.warningWritten || r.warningThreshold <= 0 || rateLimit.Limit <= 0 {
+		return
+	}
+	usedRatio := float64(rateLimit.Used) / float64(rateLimit.Limit)
+	if usedRatio < r.warningThreshold {
+		return
+	}
+
+	resetAt := "unknown"
+	resetIn := ""
+	if rateLimit.Reset != 0 {
+		resetAtTime := time.Unix(rateLimit.Reset, 0).UTC()
+		resetAt = resetAtTime.Format(time.RFC3339)
+		resetIn = fmt.Sprintf(" in %s", formatResetIn(time.Until(resetAtTime)))
+	}
+	_, _ = fmt.Fprintf(
+		os.Stderr,
+		"warning: GitHub %s API rate limit is %.0f%% used (%d/%d used, %d remaining, resets at %s%s)\n",
+		resource,
+		usedRatio*100,
+		rateLimit.Used,
+		rateLimit.Limit,
+		rateLimit.Remaining,
+		resetAt,
+		resetIn,
+	)
+	r.warningWritten = true
+}
+
+func observedBackend(observed APIUsageObserved) string {
+	switch {
+	case observed.RESTRequests > 0 && observed.GraphQLRequests > 0:
+		return "mixed"
+	case observed.RESTRequests > 0:
+		return "rest"
+	case observed.GraphQLRequests > 0:
+		return "graphql"
+	default:
+		return "none"
+	}
+}
+
+func buildRateLimitReport(after *rateLimitSnapshot) APIUsageRateLimit {
+	return APIUsageRateLimit{
+		Core:    buildRateLimitResourceReport(resourceFromSnapshot(after, "core")),
+		GraphQL: buildRateLimitResourceReport(resourceFromSnapshot(after, "graphql")),
+	}
+}
+
+func resourceFromSnapshot(snapshot *rateLimitSnapshot, resource string) *rateLimitResource {
+	if snapshot == nil {
+		return nil
+	}
+	if resource == "graphql" {
+		return &snapshot.GraphQL
+	}
+	return &snapshot.Core
+}
+
+func buildRateLimitResourceReport(after *rateLimitResource) APIUsageRateLimitResource {
+	report := APIUsageRateLimitResource{}
+	if after == nil || !after.Seen {
+		return report
+	}
+
+	report.Remaining = apiUsageIntPtr(after.Remaining)
+	report.Used = apiUsageIntPtr(after.Used)
+	if after.Limit != 0 {
+		report.Limit = apiUsageIntPtr(after.Limit)
+	}
+	if after.Reset != 0 {
+		resetAt := time.Unix(after.Reset, 0).UTC()
+		report.ResetAt = resetAt.Format(time.RFC3339)
+		report.ResetInSeconds = apiUsageInt64Ptr(maxDurationSeconds(time.Until(resetAt)))
+	}
+	return report
+}
+
+func apiUsageIntPtr(value int) *int {
+	return &value
+}
+
+func apiUsageInt64Ptr(value int64) *int64 {
+	return &value
+}
+
+func maxDurationSeconds(duration time.Duration) int64 {
+	seconds := int64(duration.Round(time.Second).Seconds())
+	if seconds < 0 {
+		return 0
+	}
+	return seconds
+}
+
+func formatResetIn(duration time.Duration) string {
+	if duration <= 0 {
+		return "now"
+	}
+	duration = duration.Round(time.Second)
+	if duration < time.Minute {
+		return duration.String()
+	}
+	duration = duration.Round(time.Minute)
+	if duration < time.Hour {
+		return duration.String()
+	}
+	duration = duration.Round(time.Minute)
+	return duration.String()
+}
+
+func parseHeaderInt(headers http.Header, name string) (int, bool) {
+	value := headers.Get(name)
+	if value == "" {
+		return 0, false
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, false
+	}
+	return parsed, true
+}
+
+func parseHeaderInt64(headers http.Header, name string) (int64, bool) {
+	value := headers.Get(name)
+	if value == "" {
+		return 0, false
+	}
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return parsed, true
+}

--- a/gh-helper/api_usage.go
+++ b/gh-helper/api_usage.go
@@ -31,6 +31,18 @@ type APIUsageObserved struct {
 	GraphQLNodeCount               int `json:"graphqlNodeCount,omitempty"`
 }
 
+type graphQLRequestTrace struct {
+	OperationType string
+	OperationName string
+	StatusCode    int
+}
+
+type restRequestTrace struct {
+	Method     string
+	Path       string
+	StatusCode int
+}
+
 type APIUsageRateLimit struct {
 	Core    *APIUsageRateLimitResource `json:"core,omitempty"`
 	GraphQL *APIUsageRateLimitResource `json:"graphql,omitempty"`
@@ -71,22 +83,18 @@ type apiUsageRecorder struct {
 	warningThreshold float64
 	warningWritten   bool
 	warningWriter    io.Writer
+	trace            bool
+	traceWriter      io.Writer
 	structuredOutput bool
 }
 
 var commandAPIUsage = &apiUsageRecorder{}
 
 func startAPIUsageForCommand(cmd *cobra.Command, _ []string) {
-	if !apiUsage {
-		commandAPIUsage.Reset(false)
-		commandAPIUsage.SetWarningThreshold(rateLimitWarningThreshold)
-		commandAPIUsage.SetWarningWriter(cmd.ErrOrStderr())
-		return
-	}
-
-	commandAPIUsage.Reset(true)
+	commandAPIUsage.Reset(apiUsage)
 	commandAPIUsage.SetWarningThreshold(rateLimitWarningThreshold)
 	commandAPIUsage.SetWarningWriter(cmd.ErrOrStderr())
+	commandAPIUsage.SetTrace(apiUsageTrace, cmd.ErrOrStderr())
 }
 
 func printAPIUsageForTextCommand(cmd *cobra.Command, _ []string) {
@@ -159,6 +167,8 @@ func (r *apiUsageRecorder) Reset(enabled bool) {
 	r.warningThreshold = 0
 	r.warningWritten = false
 	r.warningWriter = os.Stderr
+	r.trace = false
+	r.traceWriter = os.Stderr
 	r.structuredOutput = false
 }
 
@@ -180,7 +190,19 @@ func (r *apiUsageRecorder) SetWarningWriter(writer io.Writer) {
 	r.warningWriter = writer
 }
 
-func (r *apiUsageRecorder) RecordGraphQLResponse(headers http.Header, body []byte) {
+func (r *apiUsageRecorder) SetTrace(enabled bool, writer io.Writer) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.trace = enabled
+	if writer == nil {
+		r.traceWriter = os.Stderr
+		return
+	}
+	r.traceWriter = writer
+}
+
+func (r *apiUsageRecorder) RecordGraphQLResponse(headers http.Header, body []byte, trace graphQLRequestTrace) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -196,22 +218,27 @@ func (r *apiUsageRecorder) RecordGraphQLResponse(headers http.Header, body []byt
 		r.observed.GraphQLNodeCount += rateLimit.NodeCount
 		r.updateAfterFromGraphQLRateLimit(rateLimit)
 		r.lastGraphQLUsed = apiUsageIntPtr(rateLimit.Used)
+		r.writeGraphQLTraceLocked(trace, "response", &rateLimit, nil)
 		return
 	}
 	if used, ok := parseHeaderInt(headers, "x-ratelimit-used"); ok {
 		if previousUsed != nil && used > *previousUsed {
-			r.observed.GraphQLCost += used - *previousUsed
+			estimatedCost := used - *previousUsed
+			r.observed.GraphQLCost += estimatedCost
 			r.observed.GraphQLCostEstimatedRequests++
+			r.writeGraphQLTraceLocked(trace, "estimated", nil, &estimatedCost)
 		} else {
 			r.observed.GraphQLCostUnavailableRequests++
+			r.writeGraphQLTraceLocked(trace, "unavailable", nil, nil)
 		}
 		r.lastGraphQLUsed = apiUsageIntPtr(used)
 		return
 	}
 	r.observed.GraphQLCostUnavailableRequests++
+	r.writeGraphQLTraceLocked(trace, "unavailable", nil, nil)
 }
 
-func (r *apiUsageRecorder) RecordRESTResponse(headers http.Header) {
+func (r *apiUsageRecorder) RecordRESTResponse(headers http.Header, trace restRequestTrace) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -220,6 +247,7 @@ func (r *apiUsageRecorder) RecordRESTResponse(headers http.Header) {
 	}
 	r.observed.RESTRequests++
 	r.updateAfterFromHeaders("core", headers)
+	r.writeRESTTraceLocked(trace)
 }
 
 func (r *apiUsageRecorder) AddWarning(warning string) {
@@ -249,7 +277,7 @@ func (r *apiUsageRecorder) MarkStructuredOutputWritten() {
 }
 
 func (r *apiUsageRecorder) shouldTrackLocked() bool {
-	return r.enabled || r.warningThreshold > 0
+	return r.enabled || r.warningThreshold > 0 || r.trace
 }
 
 func (r *apiUsageRecorder) Finish() *APIUsageReport {
@@ -363,6 +391,102 @@ func (r *apiUsageRecorder) maybeWarnRateLimitLocked(resource string, rateLimit r
 		resetIn,
 	)
 	r.warningWritten = true
+}
+
+func (r *apiUsageRecorder) writeGraphQLTraceLocked(trace graphQLRequestTrace, costSource string, rateLimit *graphQLRateLimitTelemetry, estimatedCost *int) {
+	if !r.trace {
+		return
+	}
+
+	operation := trace.OperationType
+	if operation == "" {
+		operation = "unknown"
+	}
+	operationName := trace.OperationName
+	if operationName == "" {
+		operationName = "anonymous"
+	}
+
+	parts := []string{
+		"api-usage:",
+		"graphql",
+		fmt.Sprintf("request=%d", r.observed.GraphQLRequests),
+		fmt.Sprintf("operation=%s", operation),
+		fmt.Sprintf("name=%s", operationName),
+		fmt.Sprintf("status=%d", trace.StatusCode),
+		fmt.Sprintf("costSource=%s", costSource),
+	}
+	if rateLimit != nil {
+		parts = append(parts,
+			fmt.Sprintf("cost=%d", rateLimit.Cost),
+			fmt.Sprintf("nodeCount=%d", rateLimit.NodeCount),
+			fmt.Sprintf("used=%d/%d", rateLimit.Used, rateLimit.Limit),
+			fmt.Sprintf("remaining=%d", rateLimit.Remaining),
+		)
+		if rateLimit.ResetAt != "" {
+			parts = append(parts, "resetAt="+rateLimit.ResetAt)
+			if resetAt, err := time.Parse(time.RFC3339, rateLimit.ResetAt); err == nil {
+				parts = append(parts, "resetIn="+formatResetIn(time.Until(resetAt)))
+			}
+		}
+	} else {
+		if estimatedCost != nil {
+			parts = append(parts, fmt.Sprintf("estimatedCost=%d", *estimatedCost))
+		}
+		parts = appendRateLimitHeaderTraceParts(parts, resourceFromSnapshot(r.after, "graphql"))
+	}
+
+	r.writeTraceLineLocked(strings.Join(parts, " "))
+}
+
+func (r *apiUsageRecorder) writeRESTTraceLocked(trace restRequestTrace) {
+	if !r.trace {
+		return
+	}
+
+	method := trace.Method
+	if method == "" {
+		method = "UNKNOWN"
+	}
+	path := trace.Path
+	if path == "" {
+		path = "unknown"
+	}
+	parts := []string{
+		"api-usage:",
+		"rest",
+		fmt.Sprintf("request=%d", r.observed.RESTRequests),
+		fmt.Sprintf("method=%s", method),
+		fmt.Sprintf("path=%s", path),
+		fmt.Sprintf("status=%d", trace.StatusCode),
+	}
+	parts = appendRateLimitHeaderTraceParts(parts, resourceFromSnapshot(r.after, "core"))
+	r.writeTraceLineLocked(strings.Join(parts, " "))
+}
+
+func (r *apiUsageRecorder) writeTraceLineLocked(line string) {
+	writer := r.traceWriter
+	if writer == nil {
+		writer = os.Stderr
+	}
+	_, _ = fmt.Fprintln(writer, line)
+}
+
+func appendRateLimitHeaderTraceParts(parts []string, rateLimit *rateLimitResource) []string {
+	if rateLimit == nil || !rateLimit.Seen {
+		return parts
+	}
+	if rateLimit.Limit != 0 {
+		parts = append(parts, fmt.Sprintf("used=%d/%d", rateLimit.Used, rateLimit.Limit))
+	} else {
+		parts = append(parts, fmt.Sprintf("used=%d", rateLimit.Used))
+	}
+	parts = append(parts, fmt.Sprintf("remaining=%d", rateLimit.Remaining))
+	if rateLimit.Reset != 0 {
+		resetAt := time.Unix(rateLimit.Reset, 0).UTC()
+		parts = append(parts, "resetAt="+resetAt.Format(time.RFC3339), "resetIn="+formatResetIn(time.Until(resetAt)))
+	}
+	return parts
 }
 
 func observedBackend(observed APIUsageObserved) string {

--- a/gh-helper/api_usage_test.go
+++ b/gh-helper/api_usage_test.go
@@ -203,6 +203,81 @@ func TestAPIUsageRecorderUsesWarningWriter(t *testing.T) {
 	}
 }
 
+func TestAPIUsageRecorderWarnsPerResource(t *testing.T) {
+	t.Parallel()
+
+	recorder := &apiUsageRecorder{}
+	var stderr bytes.Buffer
+	recorder.Reset(false)
+	recorder.SetWarningThreshold(0.5)
+	recorder.SetWarningWriter(&stderr)
+
+	restHeaders := http.Header{}
+	restHeaders.Set("x-ratelimit-limit", "100")
+	restHeaders.Set("x-ratelimit-used", "60")
+	restHeaders.Set("x-ratelimit-remaining", "40")
+	recorder.RecordRESTResponse(restHeaders, restRequestTrace{})
+
+	graphQLHeaders := http.Header{}
+	graphQLHeaders.Set("x-ratelimit-limit", "100")
+	graphQLHeaders.Set("x-ratelimit-used", "70")
+	graphQLHeaders.Set("x-ratelimit-remaining", "30")
+	recorder.RecordGraphQLResponse(graphQLHeaders, nil, graphQLRequestTrace{})
+
+	got := stderr.String()
+	for _, want := range []string{
+		"GitHub core API rate limit is 60% used",
+		"GitHub graphql API rate limit is 70% used",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("warning output %q does not contain %q", got, want)
+		}
+	}
+}
+
+func TestAPIUsageRecorderSkipsGraphQLBodyParseForWarningOnly(t *testing.T) {
+	t.Parallel()
+
+	recorder := &apiUsageRecorder{}
+	recorder.Reset(false)
+	recorder.SetWarningThreshold(0.5)
+
+	headers := http.Header{}
+	headers.Set("x-ratelimit-limit", "5000")
+	headers.Set("x-ratelimit-remaining", "4999")
+	headers.Set("x-ratelimit-used", "1")
+
+	recorder.RecordGraphQLResponse(headers, []byte(`{
+		"data": {
+			"ghHelperApiUsageRateLimit": {
+				"cost": 99,
+				"limit": 5000,
+				"nodeCount": 999,
+				"remaining": 4900,
+				"used": 100,
+				"resetAt": "2026-05-03T12:00:00Z"
+			}
+		}
+	}`), graphQLRequestTrace{})
+
+	recorder.mu.Lock()
+	report := recorder.buildReportLocked()
+	recorder.mu.Unlock()
+
+	if report.Observed.GraphQLRequests != 0 {
+		t.Fatalf("GraphQLRequests = %d, want 0", report.Observed.GraphQLRequests)
+	}
+	if report.Observed.GraphQLCost != 0 {
+		t.Fatalf("GraphQLCost = %d, want 0", report.Observed.GraphQLCost)
+	}
+	if report.RateLimit == nil || report.RateLimit.GraphQL == nil {
+		t.Fatalf("GraphQL rate limit report is nil")
+	}
+	if report.RateLimit.GraphQL.Used == nil || *report.RateLimit.GraphQL.Used != 1 {
+		t.Fatalf("GraphQL used = %v, want header value 1", report.RateLimit.GraphQL.Used)
+	}
+}
+
 func TestAPIUsageRecorderWritesGraphQLTrace(t *testing.T) {
 	t.Parallel()
 
@@ -247,6 +322,36 @@ func TestAPIUsageRecorderWritesGraphQLTrace(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("trace output %q does not contain %q", got, want)
 		}
+	}
+}
+
+func TestAttachAPIUsageToOutputAlwaysWrapsData(t *testing.T) {
+	oldAPIUsage := apiUsage
+	defer func() { apiUsage = oldAPIUsage }()
+	apiUsage = true
+
+	commandAPIUsage.Reset(true)
+	got, attached := attachAPIUsageToOutput(nil, map[string]interface{}{"value": 1})
+	if !attached {
+		t.Fatal("attached = false, want true")
+	}
+
+	output, ok := got.(map[string]interface{})
+	if !ok {
+		t.Fatalf("output type = %T, want map[string]interface{}", got)
+	}
+	if _, ok := output["apiUsage"]; !ok {
+		t.Fatalf("output missing apiUsage: %#v", output)
+	}
+	data, ok := output["data"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("data type = %T, want map[string]interface{}", output["data"])
+	}
+	if data["value"] != 1 {
+		t.Fatalf("data[value] = %v, want 1", data["value"])
+	}
+	if _, ok := output["value"]; ok {
+		t.Fatalf("output should not inject original map fields at root: %#v", output)
 	}
 }
 

--- a/gh-helper/api_usage_test.go
+++ b/gh-helper/api_usage_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"strings"
@@ -46,6 +47,9 @@ func TestAPIUsageRecorderEstimatesGraphQLCostFromSequentialHeaders(t *testing.T)
 	}
 	if report.Observed.GraphQLCostUnavailableRequests != 1 {
 		t.Fatalf("GraphQLCostUnavailableRequests = %d, want 1", report.Observed.GraphQLCostUnavailableRequests)
+	}
+	if report.RateLimit == nil || report.RateLimit.GraphQL == nil {
+		t.Fatalf("GraphQL rate limit report is nil")
 	}
 	if report.RateLimit.GraphQL.Remaining == nil || *report.RateLimit.GraphQL.Remaining != 4889 {
 		t.Fatalf("Remaining = %v, want 4889", report.RateLimit.GraphQL.Remaining)
@@ -120,6 +124,9 @@ func TestAPIUsageRecorderPrefersGraphQLCostFromResponse(t *testing.T) {
 	if report.Observed.GraphQLNodeCount != 9 {
 		t.Fatalf("GraphQLNodeCount = %d, want response node count 9", report.Observed.GraphQLNodeCount)
 	}
+	if report.RateLimit == nil || report.RateLimit.GraphQL == nil {
+		t.Fatalf("GraphQL rate limit report is nil")
+	}
 	if report.RateLimit.GraphQL.Limit == nil || *report.RateLimit.GraphQL.Limit != 5000 {
 		t.Fatalf("GraphQL limit = %v, want 5000", report.RateLimit.GraphQL.Limit)
 	}
@@ -147,8 +154,8 @@ func TestFormatAPIUsageSummary(t *testing.T) {
 			GraphQLRequests: 2,
 			GraphQLCost:     7,
 		},
-		RateLimit: APIUsageRateLimit{
-			GraphQL: APIUsageRateLimitResource{
+		RateLimit: &APIUsageRateLimit{
+			GraphQL: &APIUsageRateLimitResource{
 				Remaining: &remaining,
 			},
 		},
@@ -158,5 +165,40 @@ func TestFormatAPIUsageSummary(t *testing.T) {
 		if !strings.Contains(summary, want) {
 			t.Fatalf("summary %q does not contain %q", summary, want)
 		}
+	}
+}
+
+func TestAPIUsageRecorderOmitsUnseenRateLimit(t *testing.T) {
+	t.Parallel()
+
+	recorder := &apiUsageRecorder{}
+	recorder.Reset(true)
+
+	recorder.mu.Lock()
+	report := recorder.buildReportLocked()
+	recorder.mu.Unlock()
+
+	if report.RateLimit != nil {
+		t.Fatalf("RateLimit = %#v, want nil", report.RateLimit)
+	}
+}
+
+func TestAPIUsageRecorderUsesWarningWriter(t *testing.T) {
+	t.Parallel()
+
+	recorder := &apiUsageRecorder{}
+	var stderr bytes.Buffer
+	recorder.Reset(false)
+	recorder.SetWarningThreshold(0.5)
+	recorder.SetWarningWriter(&stderr)
+
+	headers := http.Header{}
+	headers.Set("x-ratelimit-limit", "100")
+	headers.Set("x-ratelimit-used", "75")
+	headers.Set("x-ratelimit-remaining", "25")
+	recorder.RecordGraphQLResponse(headers, nil)
+
+	if got := stderr.String(); !strings.Contains(got, "GitHub graphql API rate limit is 75% used") {
+		t.Fatalf("warning output = %q", got)
 	}
 }

--- a/gh-helper/api_usage_test.go
+++ b/gh-helper/api_usage_test.go
@@ -235,6 +235,36 @@ func TestAPIUsageRecorderWarnsPerResource(t *testing.T) {
 	}
 }
 
+func TestAPIUsageRecorderIncludesRateLimitWarningsInReport(t *testing.T) {
+	t.Parallel()
+
+	recorder := &apiUsageRecorder{}
+	var stderr bytes.Buffer
+	recorder.Reset(true)
+	recorder.SetWarningThreshold(0.5)
+	recorder.SetWarningWriter(&stderr)
+
+	headers := http.Header{}
+	headers.Set("x-ratelimit-limit", "100")
+	headers.Set("x-ratelimit-used", "75")
+	headers.Set("x-ratelimit-remaining", "25")
+	recorder.RecordGraphQLResponse(headers, nil, graphQLRequestTrace{})
+
+	recorder.mu.Lock()
+	report := recorder.buildReportLocked()
+	recorder.mu.Unlock()
+
+	if len(report.Warnings) != 1 {
+		t.Fatalf("Warnings length = %d, want 1: %#v", len(report.Warnings), report.Warnings)
+	}
+	if !strings.Contains(report.Warnings[0], "GitHub graphql API rate limit is 75% used") {
+		t.Fatalf("warning = %q", report.Warnings[0])
+	}
+	if got := stderr.String(); !strings.Contains(got, "warning: "+report.Warnings[0]) {
+		t.Fatalf("stderr warning %q does not contain structured warning %q", got, report.Warnings[0])
+	}
+}
+
 func TestAPIUsageRecorderSkipsGraphQLBodyParseForWarningOnly(t *testing.T) {
 	t.Parallel()
 
@@ -275,6 +305,40 @@ func TestAPIUsageRecorderSkipsGraphQLBodyParseForWarningOnly(t *testing.T) {
 	}
 	if report.RateLimit.GraphQL.Used == nil || *report.RateLimit.GraphQL.Used != 1 {
 		t.Fatalf("GraphQL used = %v, want header value 1", report.RateLimit.GraphQL.Used)
+	}
+}
+
+func TestAPIUsageRecorderSkipsGraphQLBodyParseWithoutAlias(t *testing.T) {
+	t.Parallel()
+
+	recorder := &apiUsageRecorder{}
+	recorder.Reset(true)
+
+	headers := http.Header{}
+	headers.Set("x-ratelimit-limit", "5000")
+	headers.Set("x-ratelimit-remaining", "4999")
+	headers.Set("x-ratelimit-used", "1")
+
+	recorder.RecordGraphQLResponse(headers, []byte(`{
+		"data": {
+			"repository": {
+				"id": "R_1"
+			}
+		}
+	}`), graphQLRequestTrace{})
+
+	recorder.mu.Lock()
+	report := recorder.buildReportLocked()
+	recorder.mu.Unlock()
+
+	if report.Observed.GraphQLRequests != 1 {
+		t.Fatalf("GraphQLRequests = %d, want 1", report.Observed.GraphQLRequests)
+	}
+	if report.Observed.GraphQLCostKnownRequests != 0 {
+		t.Fatalf("GraphQLCostKnownRequests = %d, want 0", report.Observed.GraphQLCostKnownRequests)
+	}
+	if report.Observed.GraphQLCostUnavailableRequests != 1 {
+		t.Fatalf("GraphQLCostUnavailableRequests = %d, want 1", report.Observed.GraphQLCostUnavailableRequests)
 	}
 }
 

--- a/gh-helper/api_usage_test.go
+++ b/gh-helper/api_usage_test.go
@@ -183,6 +183,75 @@ func TestAPIUsageRecorderOmitsUnseenRateLimit(t *testing.T) {
 	}
 }
 
+func TestAPIUsageRecorderOmitsUnseenRateLimitFields(t *testing.T) {
+	t.Parallel()
+
+	recorder := &apiUsageRecorder{}
+	recorder.Reset(true)
+
+	headers := http.Header{}
+	headers.Set("x-ratelimit-limit", "5000")
+	recorder.RecordRESTResponse(headers, restRequestTrace{})
+
+	recorder.mu.Lock()
+	report := recorder.buildReportLocked()
+	recorder.mu.Unlock()
+
+	if report.RateLimit == nil || report.RateLimit.Core == nil {
+		t.Fatalf("Core rate limit report is nil")
+	}
+	if report.RateLimit.Core.Limit == nil || *report.RateLimit.Core.Limit != 5000 {
+		t.Fatalf("Limit = %v, want 5000", report.RateLimit.Core.Limit)
+	}
+	if report.RateLimit.Core.Used != nil {
+		t.Fatalf("Used = %v, want nil for unseen header", *report.RateLimit.Core.Used)
+	}
+	if report.RateLimit.Core.Remaining != nil {
+		t.Fatalf("Remaining = %v, want nil for unseen header", *report.RateLimit.Core.Remaining)
+	}
+}
+
+func TestAPIUsageRecorderDerivesUsedFromLimitAndRemaining(t *testing.T) {
+	t.Parallel()
+
+	recorder := &apiUsageRecorder{}
+	recorder.Reset(true)
+
+	headers := http.Header{}
+	headers.Set("x-ratelimit-limit", "5000")
+	headers.Set("x-ratelimit-remaining", "4990")
+	recorder.RecordRESTResponse(headers, restRequestTrace{})
+
+	recorder.mu.Lock()
+	report := recorder.buildReportLocked()
+	recorder.mu.Unlock()
+
+	if report.RateLimit == nil || report.RateLimit.Core == nil {
+		t.Fatalf("Core rate limit report is nil")
+	}
+	if report.RateLimit.Core.Used == nil || *report.RateLimit.Core.Used != 10 {
+		t.Fatalf("Used = %v, want derived value 10", report.RateLimit.Core.Used)
+	}
+}
+
+func TestAPIUsageRecorderSkipsWarningWithoutUsed(t *testing.T) {
+	t.Parallel()
+
+	recorder := &apiUsageRecorder{}
+	var stderr bytes.Buffer
+	recorder.Reset(false)
+	recorder.SetWarningThreshold(0.5)
+	recorder.SetWarningWriter(&stderr)
+
+	headers := http.Header{}
+	headers.Set("x-ratelimit-limit", "100")
+	recorder.RecordRESTResponse(headers, restRequestTrace{})
+
+	if got := stderr.String(); got != "" {
+		t.Fatalf("warning output = %q, want empty", got)
+	}
+}
+
 func TestAPIUsageRecorderUsesWarningWriter(t *testing.T) {
 	t.Parallel()
 

--- a/gh-helper/api_usage_test.go
+++ b/gh-helper/api_usage_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAPIUsageRecorderEstimatesGraphQLCostFromSequentialHeaders(t *testing.T) {
+	t.Parallel()
+
+	recorder := &apiUsageRecorder{}
+	recorder.Reset(true)
+
+	headers := http.Header{}
+	headers.Set("x-ratelimit-limit", "5000")
+	headers.Set("x-ratelimit-remaining", "4900")
+	headers.Set("x-ratelimit-used", "100")
+	headers.Set("x-ratelimit-reset", "1777809256")
+	recorder.RecordGraphQLResponse(headers, nil)
+
+	headers = http.Header{}
+	headers.Set("x-ratelimit-limit", "5000")
+	headers.Set("x-ratelimit-remaining", "4889")
+	headers.Set("x-ratelimit-used", "111")
+	headers.Set("x-ratelimit-reset", "1777809256")
+	recorder.RecordGraphQLResponse(headers, nil)
+
+	recorder.mu.Lock()
+	report := recorder.buildReportLocked()
+	recorder.mu.Unlock()
+
+	if report.Backend != "graphql" {
+		t.Fatalf("Backend = %q, want graphql", report.Backend)
+	}
+	if report.Observed.GraphQLRequests != 2 {
+		t.Fatalf("GraphQLRequests = %d, want 2", report.Observed.GraphQLRequests)
+	}
+	if report.Observed.GraphQLCost != 11 {
+		t.Fatalf("GraphQLCost = %d, want 11", report.Observed.GraphQLCost)
+	}
+	if report.Observed.GraphQLCostEstimatedRequests != 1 {
+		t.Fatalf("GraphQLCostEstimatedRequests = %d, want 1", report.Observed.GraphQLCostEstimatedRequests)
+	}
+	if report.Observed.GraphQLCostUnavailableRequests != 1 {
+		t.Fatalf("GraphQLCostUnavailableRequests = %d, want 1", report.Observed.GraphQLCostUnavailableRequests)
+	}
+	if report.RateLimit.GraphQL.Remaining == nil || *report.RateLimit.GraphQL.Remaining != 4889 {
+		t.Fatalf("Remaining = %v, want 4889", report.RateLimit.GraphQL.Remaining)
+	}
+}
+
+func TestAPIUsageRecorderReportsMixedBackend(t *testing.T) {
+	t.Parallel()
+
+	recorder := &apiUsageRecorder{}
+	recorder.Reset(true)
+
+	restHeaders := http.Header{}
+	restHeaders.Set("x-ratelimit-limit", "5000")
+	restHeaders.Set("x-ratelimit-remaining", "4998")
+	restHeaders.Set("x-ratelimit-used", "2")
+	recorder.RecordRESTResponse(restHeaders)
+
+	graphQLHeaders := http.Header{}
+	graphQLHeaders.Set("x-ratelimit-limit", "5000")
+	graphQLHeaders.Set("x-ratelimit-remaining", "4990")
+	graphQLHeaders.Set("x-ratelimit-used", "10")
+	recorder.RecordGraphQLResponse(graphQLHeaders, nil)
+
+	recorder.mu.Lock()
+	report := recorder.buildReportLocked()
+	recorder.mu.Unlock()
+
+	if report.Backend != "mixed" {
+		t.Fatalf("Backend = %q, want mixed", report.Backend)
+	}
+	if report.Observed.RESTRequests != 1 {
+		t.Fatalf("RESTRequests = %d, want 1", report.Observed.RESTRequests)
+	}
+	if report.Observed.GraphQLRequests != 1 {
+		t.Fatalf("GraphQLRequests = %d, want 1", report.Observed.GraphQLRequests)
+	}
+}
+
+func TestAPIUsageRecorderPrefersGraphQLCostFromResponse(t *testing.T) {
+	t.Parallel()
+
+	recorder := &apiUsageRecorder{}
+	recorder.Reset(true)
+	resetAt := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
+	headers := http.Header{}
+	headers.Set("x-ratelimit-used", "999")
+
+	recorder.RecordGraphQLResponse(headers, []byte(fmt.Sprintf(`{
+		"data": {
+			"ghHelperApiUsageRateLimit": {
+				"cost": 4,
+				"limit": 5000,
+				"nodeCount": 9,
+				"remaining": 4996,
+				"used": 104,
+				"resetAt": %q
+			}
+		}
+	}`, resetAt.Format(time.RFC3339))))
+
+	recorder.mu.Lock()
+	report := recorder.buildReportLocked()
+	recorder.mu.Unlock()
+
+	if report.Observed.GraphQLCost != 4 {
+		t.Fatalf("GraphQLCost = %d, want response cost 4", report.Observed.GraphQLCost)
+	}
+	if report.Observed.GraphQLCostKnownRequests != 1 {
+		t.Fatalf("GraphQLCostKnownRequests = %d, want 1", report.Observed.GraphQLCostKnownRequests)
+	}
+	if report.Observed.GraphQLNodeCount != 9 {
+		t.Fatalf("GraphQLNodeCount = %d, want response node count 9", report.Observed.GraphQLNodeCount)
+	}
+	if report.RateLimit.GraphQL.Limit == nil || *report.RateLimit.GraphQL.Limit != 5000 {
+		t.Fatalf("GraphQL limit = %v, want 5000", report.RateLimit.GraphQL.Limit)
+	}
+	if report.RateLimit.GraphQL.Remaining == nil || *report.RateLimit.GraphQL.Remaining != 4996 {
+		t.Fatalf("GraphQL remaining = %v, want 4996", report.RateLimit.GraphQL.Remaining)
+	}
+	if report.RateLimit.GraphQL.Used == nil || *report.RateLimit.GraphQL.Used != 104 {
+		t.Fatalf("GraphQL used = %v, want 104", report.RateLimit.GraphQL.Used)
+	}
+	if report.RateLimit.GraphQL.ResetAt != resetAt.Format(time.RFC3339) {
+		t.Fatalf("GraphQL resetAt = %q, want %s", report.RateLimit.GraphQL.ResetAt, resetAt.Format(time.RFC3339))
+	}
+	if report.RateLimit.GraphQL.ResetInSeconds == nil || *report.RateLimit.GraphQL.ResetInSeconds == 0 {
+		t.Fatalf("GraphQL resetInSeconds = %v, want positive value", report.RateLimit.GraphQL.ResetInSeconds)
+	}
+}
+
+func TestFormatAPIUsageSummary(t *testing.T) {
+	t.Parallel()
+
+	remaining := 123
+	summary := formatAPIUsageSummary(&APIUsageReport{
+		Backend: "graphql",
+		Observed: APIUsageObserved{
+			GraphQLRequests: 2,
+			GraphQLCost:     7,
+		},
+		RateLimit: APIUsageRateLimit{
+			GraphQL: APIUsageRateLimitResource{
+				Remaining: &remaining,
+			},
+		},
+	})
+
+	for _, want := range []string{"backend=graphql", "graphqlRequests=2", "graphqlCost=7", "graphqlRemaining=123"} {
+		if !strings.Contains(summary, want) {
+			t.Fatalf("summary %q does not contain %q", summary, want)
+		}
+	}
+}

--- a/gh-helper/api_usage_test.go
+++ b/gh-helper/api_usage_test.go
@@ -20,14 +20,14 @@ func TestAPIUsageRecorderEstimatesGraphQLCostFromSequentialHeaders(t *testing.T)
 	headers.Set("x-ratelimit-remaining", "4900")
 	headers.Set("x-ratelimit-used", "100")
 	headers.Set("x-ratelimit-reset", "1777809256")
-	recorder.RecordGraphQLResponse(headers, nil)
+	recorder.RecordGraphQLResponse(headers, nil, graphQLRequestTrace{})
 
 	headers = http.Header{}
 	headers.Set("x-ratelimit-limit", "5000")
 	headers.Set("x-ratelimit-remaining", "4889")
 	headers.Set("x-ratelimit-used", "111")
 	headers.Set("x-ratelimit-reset", "1777809256")
-	recorder.RecordGraphQLResponse(headers, nil)
+	recorder.RecordGraphQLResponse(headers, nil, graphQLRequestTrace{})
 
 	recorder.mu.Lock()
 	report := recorder.buildReportLocked()
@@ -66,13 +66,13 @@ func TestAPIUsageRecorderReportsMixedBackend(t *testing.T) {
 	restHeaders.Set("x-ratelimit-limit", "5000")
 	restHeaders.Set("x-ratelimit-remaining", "4998")
 	restHeaders.Set("x-ratelimit-used", "2")
-	recorder.RecordRESTResponse(restHeaders)
+	recorder.RecordRESTResponse(restHeaders, restRequestTrace{})
 
 	graphQLHeaders := http.Header{}
 	graphQLHeaders.Set("x-ratelimit-limit", "5000")
 	graphQLHeaders.Set("x-ratelimit-remaining", "4990")
 	graphQLHeaders.Set("x-ratelimit-used", "10")
-	recorder.RecordGraphQLResponse(graphQLHeaders, nil)
+	recorder.RecordGraphQLResponse(graphQLHeaders, nil, graphQLRequestTrace{})
 
 	recorder.mu.Lock()
 	report := recorder.buildReportLocked()
@@ -109,7 +109,7 @@ func TestAPIUsageRecorderPrefersGraphQLCostFromResponse(t *testing.T) {
 				"resetAt": %q
 			}
 		}
-	}`, resetAt.Format(time.RFC3339))))
+	}`, resetAt.Format(time.RFC3339))), graphQLRequestTrace{})
 
 	recorder.mu.Lock()
 	report := recorder.buildReportLocked()
@@ -196,9 +196,89 @@ func TestAPIUsageRecorderUsesWarningWriter(t *testing.T) {
 	headers.Set("x-ratelimit-limit", "100")
 	headers.Set("x-ratelimit-used", "75")
 	headers.Set("x-ratelimit-remaining", "25")
-	recorder.RecordGraphQLResponse(headers, nil)
+	recorder.RecordGraphQLResponse(headers, nil, graphQLRequestTrace{})
 
 	if got := stderr.String(); !strings.Contains(got, "GitHub graphql API rate limit is 75% used") {
 		t.Fatalf("warning output = %q", got)
+	}
+}
+
+func TestAPIUsageRecorderWritesGraphQLTrace(t *testing.T) {
+	t.Parallel()
+
+	recorder := &apiUsageRecorder{}
+	var stderr bytes.Buffer
+	recorder.Reset(false)
+	recorder.SetTrace(true, &stderr)
+	resetAt := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
+	headers := http.Header{}
+	headers.Set("x-ratelimit-used", "999")
+
+	recorder.RecordGraphQLResponse(headers, []byte(fmt.Sprintf(`{
+		"data": {
+			"ghHelperApiUsageRateLimit": {
+				"cost": 4,
+				"limit": 5000,
+				"nodeCount": 9,
+				"remaining": 4996,
+				"used": 104,
+				"resetAt": %q
+			}
+		}
+	}`, resetAt.Format(time.RFC3339))), graphQLRequestTrace{
+		OperationType: "query",
+		OperationName: "ReviewThreads",
+		StatusCode:    http.StatusOK,
+	})
+
+	got := stderr.String()
+	for _, want := range []string{
+		"api-usage: graphql request=1",
+		"operation=query",
+		"name=ReviewThreads",
+		"status=200",
+		"costSource=response",
+		"cost=4",
+		"nodeCount=9",
+		"used=104/5000",
+		"remaining=4996",
+		"resetIn=",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("trace output %q does not contain %q", got, want)
+		}
+	}
+}
+
+func TestAPIUsageRecorderWritesRESTTrace(t *testing.T) {
+	t.Parallel()
+
+	recorder := &apiUsageRecorder{}
+	var stderr bytes.Buffer
+	recorder.Reset(false)
+	recorder.SetTrace(true, &stderr)
+	headers := http.Header{}
+	headers.Set("x-ratelimit-limit", "5000")
+	headers.Set("x-ratelimit-used", "2")
+	headers.Set("x-ratelimit-remaining", "4998")
+
+	recorder.RecordRESTResponse(headers, restRequestTrace{
+		Method:     http.MethodPost,
+		Path:       "/repos/apstndb/gh-dev-tools/issues/63/comments",
+		StatusCode: http.StatusCreated,
+	})
+
+	got := stderr.String()
+	for _, want := range []string{
+		"api-usage: rest request=1",
+		"method=POST",
+		"path=/repos/apstndb/gh-dev-tools/issues/63/comments",
+		"status=201",
+		"used=2/5000",
+		"remaining=4998",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("trace output %q does not contain %q", got, want)
+		}
 	}
 }

--- a/gh-helper/github.go
+++ b/gh-helper/github.go
@@ -159,9 +159,13 @@ func (c *GitHubClient) RunGraphQLQueryWithVariables(query string, variables map[
 	}
 
 	// Prepare GraphQL request
+	requestQuery, injectedRateLimit := injectGraphQLRateLimit(query)
 	reqPayload := GraphQLRequest{
-		Query:     query,
+		Query:     requestQuery,
 		Variables: variables,
+	}
+	if apiUsage && !injectedRateLimit && isGraphQLQueryOperation(query) {
+		commandAPIUsage.AddWarning("could not inject rateLimit cost field into GraphQL query; cost may be unavailable")
 	}
 
 	// Use unified JSON marshaling for GitHub API
@@ -197,6 +201,7 @@ func (c *GitHubClient) RunGraphQLQueryWithVariables(query string, variables map[
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
+	commandAPIUsage.RecordGraphQLResponse(resp.Header, buf.Bytes())
 
 	// Check HTTP status
 	if resp.StatusCode != http.StatusOK {
@@ -328,6 +333,7 @@ func (c *GitHubClient) CreatePRConversationCommentREST(prNumber, body string) er
 	if err != nil {
 		return fmt.Errorf("failed to execute REST comment request: %w", err)
 	}
+	commandAPIUsage.RecordRESTResponse(resp.Header)
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
 			slog.Warn("failed to close response body", "url", resp.Request.URL.String(), "error", err)

--- a/gh-helper/github.go
+++ b/gh-helper/github.go
@@ -160,6 +160,7 @@ func (c *GitHubClient) RunGraphQLQueryWithVariables(query string, variables map[
 
 	// Prepare GraphQL request
 	requestQuery, injectedRateLimit := injectGraphQLRateLimit(query)
+	operationType, operationName := graphQLOperationTrace(query)
 	reqPayload := GraphQLRequest{
 		Query:     requestQuery,
 		Variables: variables,
@@ -201,7 +202,11 @@ func (c *GitHubClient) RunGraphQLQueryWithVariables(query string, variables map[
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
-	commandAPIUsage.RecordGraphQLResponse(resp.Header, buf.Bytes())
+	commandAPIUsage.RecordGraphQLResponse(resp.Header, buf.Bytes(), graphQLRequestTrace{
+		OperationType: operationType,
+		OperationName: operationName,
+		StatusCode:    resp.StatusCode,
+	})
 
 	// Check HTTP status
 	if resp.StatusCode != http.StatusOK {
@@ -333,7 +338,11 @@ func (c *GitHubClient) CreatePRConversationCommentREST(prNumber, body string) er
 	if err != nil {
 		return fmt.Errorf("failed to execute REST comment request: %w", err)
 	}
-	commandAPIUsage.RecordRESTResponse(resp.Header)
+	commandAPIUsage.RecordRESTResponse(resp.Header, restRequestTrace{
+		Method:     req.Method,
+		Path:       req.URL.Path,
+		StatusCode: resp.StatusCode,
+	})
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
 			slog.Warn("failed to close response body", "url", resp.Request.URL.String(), "error", err)

--- a/gh-helper/graphql_rate_limit.go
+++ b/gh-helper/graphql_rate_limit.go
@@ -64,6 +64,26 @@ func isGraphQLQueryOperation(query string) bool {
 	return readGraphQLName(query, operationStart) == "query"
 }
 
+func graphQLOperationTrace(query string) (string, string) {
+	operationStart, ok := findGraphQLOperationStart(query)
+	if !ok {
+		return "", ""
+	}
+	if query[operationStart] == '{' {
+		return "query", "anonymous"
+	}
+
+	operationType := readGraphQLName(query, operationStart)
+	pos := skipGraphQLWhitespaceAndComments(query, operationStart+len(operationType))
+	if pos >= len(query) || query[pos] == '(' || query[pos] == '{' {
+		return operationType, "anonymous"
+	}
+	if isGraphQLNameRune(rune(query[pos])) {
+		return operationType, readGraphQLName(query, pos)
+	}
+	return operationType, "anonymous"
+}
+
 func graphQLRateLimitFromResponse(body []byte) (graphQLRateLimitTelemetry, bool) {
 	var response struct {
 		Data map[string]json.RawMessage `json:"data"`
@@ -145,6 +165,24 @@ func readGraphQLName(query string, pos int) string {
 		end++
 	}
 	return query[pos:end]
+}
+
+func skipGraphQLWhitespaceAndComments(query string, pos int) int {
+	for pos < len(query) {
+		r := rune(query[pos])
+		if unicode.IsSpace(r) || r == ',' {
+			pos++
+			continue
+		}
+		if r == '#' {
+			for pos < len(query) && query[pos] != '\n' {
+				pos++
+			}
+			continue
+		}
+		return pos
+	}
+	return pos
 }
 
 type graphQLScanner struct {

--- a/gh-helper/graphql_rate_limit.go
+++ b/gh-helper/graphql_rate_limit.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"unicode"
+)
+
+const graphQLRateLimitAlias = "ghHelperApiUsageRateLimit"
+
+type graphQLRateLimitTelemetry struct {
+	Cost      int    `json:"cost"`
+	Limit     int    `json:"limit"`
+	NodeCount int    `json:"nodeCount"`
+	Remaining int    `json:"remaining"`
+	Used      int    `json:"used"`
+	ResetAt   string `json:"resetAt"`
+}
+
+func injectGraphQLRateLimit(query string) (string, bool) {
+	if strings.Contains(query, graphQLRateLimitAlias) {
+		return query, true
+	}
+
+	operationStart, ok := findGraphQLOperationStart(query)
+	if !ok {
+		return query, false
+	}
+
+	operation := readGraphQLName(query, operationStart)
+	if operation == "mutation" || operation == "subscription" {
+		return query, false
+	}
+
+	var openBrace int
+	if operation == "" && query[operationStart] == '{' {
+		openBrace = operationStart
+	} else if operation == "query" {
+		openBrace = findNextGraphQLSelectionBrace(query, operationStart+len(operation))
+	} else {
+		return query, false
+	}
+	if openBrace < 0 {
+		return query, false
+	}
+
+	closeBrace := findMatchingGraphQLBrace(query, openBrace)
+	if closeBrace < 0 {
+		return query, false
+	}
+
+	injected := "\n  " + graphQLRateLimitAlias + ": rateLimit {\n    cost\n    limit\n    nodeCount\n    remaining\n    used\n    resetAt\n  }\n"
+	return query[:closeBrace] + injected + query[closeBrace:], true
+}
+
+func isGraphQLQueryOperation(query string) bool {
+	operationStart, ok := findGraphQLOperationStart(query)
+	if !ok {
+		return false
+	}
+	if query[operationStart] == '{' {
+		return true
+	}
+	return readGraphQLName(query, operationStart) == "query"
+}
+
+func graphQLRateLimitFromResponse(body []byte) (graphQLRateLimitTelemetry, bool) {
+	var response struct {
+		Data map[string]json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return graphQLRateLimitTelemetry{}, false
+	}
+	raw, ok := response.Data[graphQLRateLimitAlias]
+	if !ok {
+		return graphQLRateLimitTelemetry{}, false
+	}
+	var rateLimit graphQLRateLimitTelemetry
+	if err := json.Unmarshal(raw, &rateLimit); err != nil {
+		return graphQLRateLimitTelemetry{}, false
+	}
+	return rateLimit, true
+}
+
+func findGraphQLOperationStart(query string) (int, bool) {
+	scanner := graphQLScanner{input: query}
+	for {
+		token, pos, ok := scanner.nextToken()
+		if !ok {
+			return 0, false
+		}
+		switch token {
+		case "{":
+			return pos, true
+		case "query", "mutation", "subscription":
+			return pos, true
+		case "fragment":
+			if !scanner.skipFragmentDefinition() {
+				return 0, false
+			}
+		}
+	}
+}
+
+func findNextGraphQLSelectionBrace(query string, start int) int {
+	scanner := graphQLScanner{input: query, pos: start}
+	for {
+		token, pos, ok := scanner.nextToken()
+		if !ok {
+			return -1
+		}
+		if token == "{" {
+			return pos
+		}
+	}
+}
+
+func findMatchingGraphQLBrace(query string, openBrace int) int {
+	scanner := graphQLScanner{input: query, pos: openBrace}
+	depth := 0
+	for {
+		token, pos, ok := scanner.nextToken()
+		if !ok {
+			return -1
+		}
+		switch token {
+		case "{":
+			depth++
+		case "}":
+			depth--
+			if depth == 0 {
+				return pos
+			}
+		}
+	}
+}
+
+func readGraphQLName(query string, pos int) string {
+	end := pos
+	for end < len(query) {
+		r := rune(query[end])
+		if !isGraphQLNameRune(r) {
+			break
+		}
+		end++
+	}
+	return query[pos:end]
+}
+
+type graphQLScanner struct {
+	input string
+	pos   int
+}
+
+func (s *graphQLScanner) nextToken() (string, int, bool) {
+	for s.pos < len(s.input) {
+		r := rune(s.input[s.pos])
+		if unicode.IsSpace(r) || r == ',' {
+			s.pos++
+			continue
+		}
+		if r == '#' {
+			s.skipLineComment()
+			continue
+		}
+		if r == '"' {
+			if strings.HasPrefix(s.input[s.pos:], `"""`) {
+				s.skipBlockString()
+			} else {
+				s.skipString()
+			}
+			continue
+		}
+		if r == '{' || r == '}' {
+			pos := s.pos
+			s.pos++
+			return string(r), pos, true
+		}
+		if isGraphQLNameRune(r) {
+			start := s.pos
+			for s.pos < len(s.input) && isGraphQLNameRune(rune(s.input[s.pos])) {
+				s.pos++
+			}
+			return s.input[start:s.pos], start, true
+		}
+		s.pos++
+	}
+	return "", 0, false
+}
+
+func (s *graphQLScanner) skipFragmentDefinition() bool {
+	depth := 0
+	seenOpen := false
+	for {
+		token, _, ok := s.nextToken()
+		if !ok {
+			return false
+		}
+		switch token {
+		case "{":
+			depth++
+			seenOpen = true
+		case "}":
+			depth--
+			if seenOpen && depth == 0 {
+				return true
+			}
+		}
+	}
+}
+
+func (s *graphQLScanner) skipLineComment() {
+	for s.pos < len(s.input) && s.input[s.pos] != '\n' {
+		s.pos++
+	}
+}
+
+func (s *graphQLScanner) skipString() {
+	s.pos++
+	for s.pos < len(s.input) {
+		if s.input[s.pos] == '\\' {
+			s.pos += 2
+			continue
+		}
+		if s.input[s.pos] == '"' {
+			s.pos++
+			return
+		}
+		s.pos++
+	}
+}
+
+func (s *graphQLScanner) skipBlockString() {
+	s.pos += 3
+	if end := bytes.Index([]byte(s.input[s.pos:]), []byte(`"""`)); end >= 0 {
+		s.pos += end + 3
+		return
+	}
+	s.pos = len(s.input)
+}
+
+func isGraphQLNameRune(r rune) bool {
+	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+}

--- a/gh-helper/graphql_rate_limit.go
+++ b/gh-helper/graphql_rate_limit.go
@@ -124,13 +124,23 @@ func findGraphQLOperationStart(query string) (int, bool) {
 
 func findNextGraphQLSelectionBrace(query string, start int) int {
 	scanner := graphQLScanner{input: query, pos: start}
+	depth := 0
 	for {
 		token, pos, ok := scanner.nextToken()
 		if !ok {
 			return -1
 		}
-		if token == "{" {
-			return pos
+		switch token {
+		case "(":
+			depth++
+		case ")":
+			if depth > 0 {
+				depth--
+			}
+		case "{":
+			if depth == 0 {
+				return pos
+			}
 		}
 	}
 }
@@ -209,7 +219,7 @@ func (s *graphQLScanner) nextToken() (string, int, bool) {
 			}
 			continue
 		}
-		if r == '{' || r == '}' {
+		if r == '{' || r == '}' || r == '(' || r == ')' {
 			pos := s.pos
 			s.pos++
 			return string(r), pos, true

--- a/gh-helper/graphql_rate_limit.go
+++ b/gh-helper/graphql_rate_limit.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"strings"
 	"unicode"
@@ -233,7 +232,7 @@ func (s *graphQLScanner) skipString() {
 
 func (s *graphQLScanner) skipBlockString() {
 	s.pos += 3
-	if end := bytes.Index([]byte(s.input[s.pos:]), []byte(`"""`)); end >= 0 {
+	if end := strings.Index(s.input[s.pos:], `"""`); end >= 0 {
 		s.pos += end + 3
 		return
 	}

--- a/gh-helper/graphql_rate_limit_test.go
+++ b/gh-helper/graphql_rate_limit_test.go
@@ -100,3 +100,50 @@ func TestGraphQLRateLimitFromResponse(t *testing.T) {
 		t.Fatalf("graphQLRateLimitFromResponse() nodeCount = %d, want 42", rateLimit.NodeCount)
 	}
 }
+
+func TestGraphQLOperationTrace(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		query         string
+		wantOperation string
+		wantName      string
+	}{
+		{
+			name:          "named query",
+			query:         `query ReviewThreads($owner: String!) { repository(owner: $owner, name: "repo") { id } }`,
+			wantOperation: "query",
+			wantName:      "ReviewThreads",
+		},
+		{
+			name:          "anonymous query with variables",
+			query:         `query($owner: String!) { viewer { login } }`,
+			wantOperation: "query",
+			wantName:      "anonymous",
+		},
+		{
+			name:          "short anonymous query",
+			query:         `{ viewer { login } }`,
+			wantOperation: "query",
+			wantName:      "anonymous",
+		},
+		{
+			name:          "named mutation",
+			query:         `mutation ResolveThread($id: ID!) { resolveReviewThread(input: {threadId: $id}) { thread { id } } }`,
+			wantOperation: "mutation",
+			wantName:      "ResolveThread",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotOperation, gotName := graphQLOperationTrace(tt.query)
+			if gotOperation != tt.wantOperation || gotName != tt.wantName {
+				t.Fatalf("graphQLOperationTrace() = (%q, %q), want (%q, %q)", gotOperation, gotName, tt.wantOperation, tt.wantName)
+			}
+		})
+	}
+}

--- a/gh-helper/graphql_rate_limit_test.go
+++ b/gh-helper/graphql_rate_limit_test.go
@@ -54,6 +54,32 @@ query($owner: String!, $repo: String!) {
 	}
 }
 
+func TestInjectGraphQLRateLimitSkipsDirectiveArgumentObject(t *testing.T) {
+	t.Parallel()
+
+	query := `query($owner: String!, $repo: String!) @custom(config: {key: "val"}) {
+  repository(owner: $owner, name: $repo) {
+    id
+  }
+}`
+
+	got, ok := injectGraphQLRateLimit(query)
+	if !ok {
+		t.Fatal("injectGraphQLRateLimit() ok = false, want true")
+	}
+	injectedAt := strings.Index(got, graphQLRateLimitAlias)
+	repositoryAt := strings.Index(got, "repository")
+	if injectedAt < 0 {
+		t.Fatalf("injected query does not contain rateLimit alias:\n%s", got)
+	}
+	if injectedAt < repositoryAt {
+		t.Fatalf("rateLimit was injected before the root selection body:\n%s", got)
+	}
+	if strings.Contains(got, "@custom(config: {\n  "+graphQLRateLimitAlias) {
+		t.Fatalf("rateLimit was injected into directive arguments:\n%s", got)
+	}
+}
+
 func TestInjectGraphQLRateLimitSkipsMutation(t *testing.T) {
 	t.Parallel()
 

--- a/gh-helper/graphql_rate_limit_test.go
+++ b/gh-helper/graphql_rate_limit_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInjectGraphQLRateLimitIntoNamedQuery(t *testing.T) {
+	t.Parallel()
+
+	query := `query($owner: String!, $repo: String!) {
+  repository(owner: $owner, name: $repo) {
+    id
+  }
+}`
+
+	got, ok := injectGraphQLRateLimit(query)
+	if !ok {
+		t.Fatal("injectGraphQLRateLimit() ok = false, want true")
+	}
+	if !strings.Contains(got, "ghHelperApiUsageRateLimit: rateLimit") {
+		t.Fatalf("injected query does not contain rateLimit alias:\n%s", got)
+	}
+	if !strings.Contains(got, "cost") {
+		t.Fatalf("injected query does not contain cost field:\n%s", got)
+	}
+	if !strings.Contains(got, "nodeCount") {
+		t.Fatalf("injected query does not contain nodeCount field:\n%s", got)
+	}
+}
+
+func TestInjectGraphQLRateLimitWithLeadingFragment(t *testing.T) {
+	t.Parallel()
+
+	query := `fragment RepoFields on Repository {
+  id
+}
+
+query($owner: String!, $repo: String!) {
+  repository(owner: $owner, name: $repo) {
+    ...RepoFields
+  }
+}`
+
+	got, ok := injectGraphQLRateLimit(query)
+	if !ok {
+		t.Fatal("injectGraphQLRateLimit() ok = false, want true")
+	}
+	if !strings.Contains(got, "ghHelperApiUsageRateLimit: rateLimit") {
+		t.Fatalf("injected query does not contain rateLimit alias:\n%s", got)
+	}
+	if strings.Index(got, "ghHelperApiUsageRateLimit") < strings.Index(got, "query(") {
+		t.Fatalf("rateLimit was injected before operation instead of inside query:\n%s", got)
+	}
+}
+
+func TestInjectGraphQLRateLimitSkipsMutation(t *testing.T) {
+	t.Parallel()
+
+	mutation := `mutation($id: ID!) {
+  resolveReviewThread(input: {threadId: $id}) {
+    thread {
+      id
+    }
+  }
+}`
+
+	got, ok := injectGraphQLRateLimit(mutation)
+	if ok {
+		t.Fatal("injectGraphQLRateLimit() ok = true, want false")
+	}
+	if got != mutation {
+		t.Fatal("mutation should not be modified")
+	}
+}
+
+func TestGraphQLRateLimitFromResponse(t *testing.T) {
+	t.Parallel()
+
+	rateLimit, ok := graphQLRateLimitFromResponse([]byte(`{
+		"data": {
+			"repository": {"id": "R_1"},
+			"ghHelperApiUsageRateLimit": {
+				"cost": 12,
+				"limit": 5000,
+				"nodeCount": 42,
+				"remaining": 4988,
+				"used": 12,
+				"resetAt": "2026-05-03T12:00:00Z"
+			}
+		}
+	}`))
+	if !ok {
+		t.Fatal("graphQLRateLimitFromResponse() ok = false, want true")
+	}
+	if rateLimit.Cost != 12 {
+		t.Fatalf("graphQLRateLimitFromResponse() cost = %d, want 12", rateLimit.Cost)
+	}
+	if rateLimit.NodeCount != 42 {
+		t.Fatalf("graphQLRateLimitFromResponse() nodeCount = %d, want 42", rateLimit.NodeCount)
+	}
+}

--- a/gh-helper/main.go
+++ b/gh-helper/main.go
@@ -237,20 +237,22 @@ Examples:
 // replyWithCommitCmd removed - use 'threads reply' with --message for commit references
 
 var (
-	owner          string
-	repo           string
-	message        string
-	mentionUser    string
-	commitHash     string
-	timeoutStr     string
-	requestReview  bool
-	excludeReviews bool
-	excludeChecks  bool
-	autoResolve    bool
-	async          bool
-	detailed       bool
-	requestSummary bool
-	noSubmit       bool
+	owner                     string
+	repo                      string
+	message                   string
+	mentionUser               string
+	commitHash                string
+	timeoutStr                string
+	requestReview             bool
+	excludeReviews            bool
+	excludeChecks             bool
+	autoResolve               bool
+	async                     bool
+	detailed                  bool
+	requestSummary            bool
+	noSubmit                  bool
+	apiUsage                  bool
+	rateLimitWarningThreshold float64
 )
 
 // Common help text for PR number arguments
@@ -280,6 +282,10 @@ func init() {
 	rootCmd.PersistentFlags().Bool("json", false, "Output JSON format (alias for --format=json)")
 	rootCmd.PersistentFlags().Bool("yaml", false, "Output YAML format (alias for --format=yaml)")
 	rootCmd.PersistentFlags().String("jq", "", "Apply jq query to filter/transform output")
+	rootCmd.PersistentFlags().BoolVar(&apiUsage, "api-usage", false, "Include REST/GraphQL API usage telemetry in command output")
+	rootCmd.PersistentFlags().Float64Var(&rateLimitWarningThreshold, "rate-limit-warning-threshold", 0.5, "Warn to stderr when x-ratelimit-used divided by x-ratelimit-limit reaches this ratio (0 disables)")
+	rootCmd.PersistentPreRun = startAPIUsageForCommand
+	rootCmd.PersistentPostRun = printAPIUsageForTextCommand
 
 	// Mark all format flags as mutually exclusive
 	rootCmd.MarkFlagsMutuallyExclusive("format", "json")

--- a/gh-helper/main.go
+++ b/gh-helper/main.go
@@ -252,6 +252,7 @@ var (
 	requestSummary            bool
 	noSubmit                  bool
 	apiUsage                  bool
+	apiUsageTrace             bool
 	rateLimitWarningThreshold float64
 )
 
@@ -283,6 +284,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool("yaml", false, "Output YAML format (alias for --format=yaml)")
 	rootCmd.PersistentFlags().String("jq", "", "Apply jq query to filter/transform output")
 	rootCmd.PersistentFlags().BoolVar(&apiUsage, "api-usage", false, "Include REST/GraphQL API usage telemetry in command output")
+	rootCmd.PersistentFlags().BoolVar(&apiUsageTrace, "api-usage-trace", false, "Write one REST/GraphQL API usage line per GitHub request to stderr")
 	rootCmd.PersistentFlags().Float64Var(&rateLimitWarningThreshold, "rate-limit-warning-threshold", 0.5, "Warn to stderr when x-ratelimit-used divided by x-ratelimit-limit reaches this ratio (0 disables)")
 	rootCmd.PersistentPreRun = startAPIUsageForCommand
 	rootCmd.PersistentPostRun = printAPIUsageForTextCommand

--- a/gh-helper/output_format.go
+++ b/gh-helper/output_format.go
@@ -34,7 +34,7 @@ func ResolveFormat(cmd *cobra.Command) OutputFormat {
 	if yamlFlag, _ := cmd.Flags().GetBool("yaml"); yamlFlag {
 		return FormatYAML
 	}
-	
+
 	// Check main format flag
 	formatStr, _ := cmd.Flags().GetString("format")
 	format := OutputFormat(strings.ToLower(formatStr))
@@ -64,16 +64,17 @@ func EncodeOutputWithCmd(cmd *cobra.Command, data interface{}) error {
 	// GetString error is intentionally ignored as the jq flag is guaranteed to exist
 	// (registered in rootCmd) and will return empty string if not set
 	jqQuery, _ := cmd.Root().Flags().GetString("jq")
-	
+
 	out := cmd.OutOrStdout()
-	
+
+	data = attachAPIUsageToOutput(cmd, data)
+
 	if jqQuery != "" {
 		return EncodeOutputWithJQ(cmd.Context(), out, format, data, jqQuery)
 	}
-	
+
 	return EncodeOutput(out, format, data)
 }
-
 
 // EncodeOutputWithJQ encodes data with jq query filtering
 func EncodeOutputWithJQ(ctx context.Context, w io.Writer, format OutputFormat, data interface{}, jqQuery string) error {

--- a/gh-helper/output_format.go
+++ b/gh-helper/output_format.go
@@ -67,13 +67,18 @@ func EncodeOutputWithCmd(cmd *cobra.Command, data interface{}) error {
 
 	out := cmd.OutOrStdout()
 
-	data = attachAPIUsageToOutput(cmd, data)
+	data, attachedAPIUsage := attachAPIUsageToOutput(cmd, data)
 
+	var err error
 	if jqQuery != "" {
-		return EncodeOutputWithJQ(cmd.Context(), out, format, data, jqQuery)
+		err = EncodeOutputWithJQ(cmd.Context(), out, format, data, jqQuery)
+	} else {
+		err = EncodeOutput(out, format, data)
 	}
-
-	return EncodeOutput(out, format, data)
+	if err == nil && attachedAPIUsage {
+		commandAPIUsage.MarkStructuredOutputWritten()
+	}
+	return err
 }
 
 // EncodeOutputWithJQ encodes data with jq query filtering


### PR DESCRIPTION
## Summary
- Add `--api-usage` to include command-local REST/GraphQL usage telemetry in structured output or stderr summaries.
- Inject GraphQL `rateLimit` fields into query operations so `cost`, `nodeCount`, `limit`, `remaining`, `used`, `resetAt`, and `resetInSeconds` come from API responses when available.
- Track response header rate-limit budgets for REST and GraphQL calls, and warn on stderr when usage crosses the configurable rate-limit threshold.
- Address Copilot/Gemini review feedback by omitting empty rate-limit objects, using Cobra stderr streams, and marking structured telemetry only after successful encoding.

Fixes #57.

## Validation
- `make check`
- `make build`
- `./bin/gh-helper reviews bot-status 56 --json --api-usage --jq '.apiUsage'`
- `./bin/gh-helper reviews bot-status 56 --json --rate-limit-warning-threshold 0.01 --jq '.botStatus.pr'`
- `./bin/gh-helper reviews bot-status 63 --json --api-usage --jq '.apiUsage'`
- OpenCode diff review on PR #63: no material issues found